### PR TITLE
feat: relations field on the record

### DIFF
--- a/src/oarepo_model/presets/drafts/__init__.py
+++ b/src/oarepo_model/presets/drafts/__init__.py
@@ -23,6 +23,7 @@ from .file_records.record_with_media_files import RecordWithMediaFilesPreset
 from .records.draft_mapping import DraftMappingPreset
 from .records.draft_record import DraftPreset
 from .records.draft_record_metadata import DraftMetadataPreset
+from .records.draft_with_relations import DraftWithRelationsPreset
 from .records.parent_record import ParentRecordPreset
 from .records.parent_record_metadata import ParentRecordMetadataPreset
 from .records.parent_record_state import ParentRecordStatePreset
@@ -76,6 +77,7 @@ drafts_records_presets: list[type[Preset]] = [
     DraftPreset,
     PIDProviderPreset,
     DraftMappingPreset,
+    DraftWithRelationsPreset,
     # service layer
     DraftServiceConfigPreset,
     DraftServicePreset,

--- a/src/oarepo_model/presets/drafts/__init__.py
+++ b/src/oarepo_model/presets/drafts/__init__.py
@@ -63,6 +63,7 @@ from .services.files.no_upload_file_service_config import (
     NoUploadFileServiceConfigPreset,
 )
 from .services.records.record_schema import DraftRecordSchemaPreset
+from .services.records.relations import RelationsServiceComponentPreset
 from .services.records.service import DraftServicePreset
 from .services.records.service_config import DraftServiceConfigPreset
 
@@ -82,6 +83,7 @@ drafts_records_presets: list[type[Preset]] = [
     DraftServiceConfigPreset,
     DraftServicePreset,
     DraftRecordSchemaPreset,
+    RelationsServiceComponentPreset,
     # resource layer
     DraftResourcePreset,
     DraftResourceConfigPreset,

--- a/src/oarepo_model/presets/drafts/records/draft_with_relations.py
+++ b/src/oarepo_model/presets/drafts/records/draft_with_relations.py
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see http://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generator
+
+from invenio_records.systemfields.relations import MultiRelationsField
+
+from oarepo_model.customizations import (
+    AddMixins,
+    Customization,
+)
+from oarepo_model.model import InvenioModel
+from oarepo_model.presets import Preset
+
+if TYPE_CHECKING:
+    from oarepo_model.builder import InvenioModelBuilder
+
+
+class DraftWithRelationsPreset(Preset):
+    """
+    Preset for Draft record with relations.
+
+    This preset adds a MultiRelationsField to the Draft class, allowing it to
+    manage multiple relations. It is similar to the RecordWithRelationsPreset
+    and depends on the "relations" preset for its configuration.
+    """
+
+    modifies = [
+        "Draft",
+    ]
+
+    depends_on = ["relations"]
+
+    def apply(
+        self,
+        builder: InvenioModelBuilder,
+        model: InvenioModel,
+        dependencies: dict[str, Any],
+    ) -> Generator[Customization, None, None]:
+
+        class DraftWithRelationsMixin:
+            relations = MultiRelationsField(
+                **dependencies["relations"],
+            )
+
+        yield AddMixins(
+            "Draft",
+            DraftWithRelationsMixin,
+        )

--- a/src/oarepo_model/presets/drafts/services/records/relations.py
+++ b/src/oarepo_model/presets/drafts/services/records/relations.py
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see http://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generator
+
+from invenio_drafts_resources.services.records.components import (
+    RelationsComponent,
+)
+
+from oarepo_model.customizations import (
+    AddToList,
+    Customization,
+)
+from oarepo_model.model import InvenioModel
+from oarepo_model.presets import Preset
+
+if TYPE_CHECKING:
+    from oarepo_model.builder import InvenioModelBuilder
+
+
+class RelationsServiceComponentPreset(Preset):
+    """
+    Relations service component that adds support for relations
+    to the record service config.
+    """
+
+    modifies = [
+        "record_service_components",
+    ]
+
+    def apply(
+        self,
+        builder: InvenioModelBuilder,
+        model: InvenioModel,
+        dependencies: dict[str, Any],
+    ) -> Generator[Customization, None, None]:
+        yield AddToList("record_service_components", RelationsComponent)

--- a/src/oarepo_model/presets/records_resources/__init__.py
+++ b/src/oarepo_model/presets/records_resources/__init__.py
@@ -30,6 +30,8 @@ from .records.record import RecordPreset
 from .records.record_json_schema import RecordJSONSchemaPreset
 from .records.record_mapping import RecordMappingPreset
 from .records.record_metadata import RecordMetadataPreset
+from .records.record_with_relations import RecordWithRelationsPreset
+from .records.relations import RelationsPreset
 from .resources.files.file_resource import FileResourcePreset
 from .resources.files.file_resource_config import FileResourceConfigPreset
 from .resources.records.resource import RecordResourcePreset
@@ -66,6 +68,8 @@ records_presets = [
     MetadataJSONSchemaPreset,
     RecordMappingPreset,
     MetadataMappingPreset,
+    RelationsPreset,
+    RecordWithRelationsPreset,
     # service layer
     RecordServicePreset,
     RecordServiceConfigPreset,

--- a/src/oarepo_model/presets/records_resources/__init__.py
+++ b/src/oarepo_model/presets/records_resources/__init__.py
@@ -32,6 +32,7 @@ from .records.record_mapping import RecordMappingPreset
 from .records.record_metadata import RecordMetadataPreset
 from .records.record_with_relations import RecordWithRelationsPreset
 from .records.relations import RelationsPreset
+from .records.relations_dumper_ext import RelationsDumperExtPreset
 from .resources.files.file_resource import FileResourcePreset
 from .resources.files.file_resource_config import FileResourceConfigPreset
 from .resources.records.resource import RecordResourcePreset
@@ -70,6 +71,7 @@ records_presets = [
     MetadataMappingPreset,
     RelationsPreset,
     RecordWithRelationsPreset,
+    RelationsDumperExtPreset,
     # service layer
     RecordServicePreset,
     RecordServiceConfigPreset,

--- a/src/oarepo_model/presets/records_resources/records/dumper.py
+++ b/src/oarepo_model/presets/records_resources/records/dumper.py
@@ -15,7 +15,7 @@ from oarepo_runtime.records.systemfields.mapping import SystemFieldDumperExt
 
 from oarepo_model.customizations import (
     AddClass,
-    AddClassList,
+    AddList,
     AddMixins,
     AddToList,
     Customization,
@@ -44,17 +44,14 @@ class RecordDumperPreset(Preset):
             extensions = Dependency(
                 "record_dumper_extensions",
                 default=[],
-                transform=lambda extensions: [ext() for ext in extensions],
             )
 
         yield AddClass("RecordDumper", clazz=SearchDumper)
         yield AddMixins("RecordDumper", RecordDumperMixin)
-        yield AddClassList("record_dumper_extensions")
+        yield AddList("record_dumper_extensions")
 
-        # TODO: we might not need this extension at all, as we should implement
-        # pre_dump/post_load on our systemfields instead of methods handled
-        # by this extension !!!
+        # TODO: remove this when we review oarepo-runtime
         yield AddToList(
             "record_dumper_extensions",
-            SystemFieldDumperExt,
+            SystemFieldDumperExt(),
         )

--- a/src/oarepo_model/presets/records_resources/records/record_with_relations.py
+++ b/src/oarepo_model/presets/records_resources/records/record_with_relations.py
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see http://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generator
+
+from invenio_records.systemfields.relations import MultiRelationsField
+
+from oarepo_model.customizations import (
+    AddMixins,
+    Customization,
+)
+from oarepo_model.model import InvenioModel
+from oarepo_model.presets import Preset
+
+if TYPE_CHECKING:
+    from oarepo_model.builder import InvenioModelBuilder
+
+
+class RecordWithRelationsPreset(Preset):
+    """
+    A preset that adds a MultiRelationsField to the Record class.
+
+    This preset modifies the Record class by introducing a relations field
+    using MultiRelationsField. The relations field is configured based on
+    dependencies provided during the application of the preset.
+    """
+
+    modifies = [
+        "Record",
+    ]
+
+    depends_on = ["relations"]
+
+    def apply(
+        self,
+        builder: InvenioModelBuilder,
+        model: InvenioModel,
+        dependencies: dict[str, Any],
+    ) -> Generator[Customization, None, None]:
+
+        class RecordWithRelationsMixin:
+            relations = MultiRelationsField(
+                **dependencies["relations"],
+            )
+
+        yield AddMixins(
+            "Record",
+            RecordWithRelationsMixin,
+        )

--- a/src/oarepo_model/presets/records_resources/records/relations.py
+++ b/src/oarepo_model/presets/records_resources/records/relations.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see http://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generator
+
+from oarepo_model.customizations import AddDictionary, Customization
+from oarepo_model.model import InvenioModel
+from oarepo_model.presets import Preset
+
+if TYPE_CHECKING:
+    from oarepo_model.builder import InvenioModelBuilder
+
+
+class RelationsPreset(Preset):
+    """
+    Preset that adds "relations" dictionary to the model. If you want to add
+    a custom relation, call `AddToDictionary("relations", key, value)` in your preset
+    or customizations array.
+    """
+
+    provides = [
+        "relations",
+    ]
+
+    def apply(
+        self,
+        builder: InvenioModelBuilder,
+        model: InvenioModel,
+        dependencies: dict[str, Any],
+    ) -> Generator[Customization, None, None]:
+
+        yield AddDictionary("relations", {})

--- a/src/oarepo_model/presets/records_resources/records/relations_dumper_ext.py
+++ b/src/oarepo_model/presets/records_resources/records/relations_dumper_ext.py
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see http://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generator
+
+from invenio_records.dumpers.relations import RelationDumperExt
+
+from oarepo_model.customizations import AddToList, Customization
+from oarepo_model.model import InvenioModel
+from oarepo_model.presets import Preset
+
+if TYPE_CHECKING:
+    from oarepo_model.builder import InvenioModelBuilder
+
+
+class RelationsDumperExtPreset(Preset):
+
+    modifies = [
+        "record_dumper_extensions",
+    ]
+
+    def apply(
+        self,
+        builder: InvenioModelBuilder,
+        model: InvenioModel,
+        dependencies: dict[str, Any],
+    ) -> Generator[Customization, None, None]:
+        yield AddToList(
+            "record_dumper_extensions",
+            RelationDumperExt("relations"),
+        )

--- a/src/oarepo_model/presets/records_resources/services/files/record_with_files_schema.py
+++ b/src/oarepo_model/presets/records_resources/services/files/record_with_files_schema.py
@@ -42,6 +42,16 @@ class RecordWithFilesSchemaPreset(Preset):
 
             enabled = ma.fields.Bool()
 
+            def get_attribute(self, obj, attr, default):
+                """Override how attributes are retrieved when dumping.
+                NOTE: We have to access by attribute because although we are loading
+                    from an external pure dict, but we are dumping from a data-layer
+                    object whose fields should be accessed by attributes and not
+                    keys. Access by key runs into FilesManager key access protection
+                    and raises.
+                """
+                return getattr(obj, attr, default)
+
         class RecordWithFilesMixin(ma.Schema):
             files = NestedAttribute(FilesSchema)
 


### PR DESCRIPTION
This PR implements a relations field feature for both records and drafts by adding new presets that provide MultiRelationsField functionality. The implementation allows users to add custom relations through a configurable relations dictionary.

* Adds a RelationsPreset that provides a configurable relations dictionary
* Implements RecordWithRelationsPreset and DraftWithRelationsPreset to add MultiRelationsField to records and drafts
* Updates package exports to make the new presets available
