### PR TITLE
Polymorphic datatype

### DIFF
--- a/src/oarepo_model/datatypes/entrypoints.py
+++ b/src/oarepo_model/datatypes/entrypoints.py
@@ -16,10 +16,10 @@ from .date import (
 )
 from .multilingual import I18nDictDataType
 from .numbers import DoubleDataType, FloatDataType, IntegerDataType, LongDataType
+from .polymorphic import PolymorphicDataType
 from .relations import PIDRelation
 from .strings import FullTextDataType, FulltextWithKeywordDataType, KeywordDataType
 from .vocabularies import VocabularyDataType
-from .polymorphic import PolymorhicDataType
 
 DATA_TYPES: dict[str, type[DataType]] = {
     KeywordDataType.TYPE: KeywordDataType,
@@ -43,5 +43,5 @@ DATA_TYPES: dict[str, type[DataType]] = {
     VocabularyDataType.TYPE: VocabularyDataType,
     I18nDictDataType.TYPE: I18nDictDataType,
     DynamicObjectDataType.TYPE: DynamicObjectDataType,
-    PolymorhicDataType.TYPE: PolymorhicDataType
+    PolymorphicDataType.TYPE: PolymorphicDataType,
 }

--- a/src/oarepo_model/datatypes/entrypoints.py
+++ b/src/oarepo_model/datatypes/entrypoints.py
@@ -19,6 +19,7 @@ from .numbers import DoubleDataType, FloatDataType, IntegerDataType, LongDataTyp
 from .relations import PIDRelation
 from .strings import FullTextDataType, FulltextWithKeywordDataType, KeywordDataType
 from .vocabularies import VocabularyDataType
+from .polymorphic import PolymorhicDataType
 
 DATA_TYPES: dict[str, type[DataType]] = {
     KeywordDataType.TYPE: KeywordDataType,
@@ -42,4 +43,5 @@ DATA_TYPES: dict[str, type[DataType]] = {
     VocabularyDataType.TYPE: VocabularyDataType,
     I18nDictDataType.TYPE: I18nDictDataType,
     DynamicObjectDataType.TYPE: DynamicObjectDataType,
+    PolymorhicDataType.TYPE: PolymorhicDataType
 }

--- a/src/oarepo_model/datatypes/polymorphic.py
+++ b/src/oarepo_model/datatypes/polymorphic.py
@@ -13,66 +13,94 @@ class PolymorhicDataType(DataType):
     Data type for handling polymorphic schemas with discriminator fields.
     This allows for fields that can be one of several different types based on a discriminator field.
     """
-    
+
     TYPE = "polymorphic"
-    
-    def __init__(self, registry, name = None):
+
+    def __init__(self, registry, name=None):
         super().__init__(registry, name)
         self.discriminator: str = "type"
         self.oneof_schemas: list[dict[str, Any]] = []
         self.polymorphic_children: dict[str, DataType] = {}
-    
+
     @override
     def create_marshmallow_field(self, field_name, element) -> ma.fields.Field:
         """
         Create a Marshmallow field for polymorphic data type.
         Uses OneOf field with different schemas based on discriminator.
         """
-        
+
         if element.get("marshmallow_field") is not None:
             return obj_or_import_string(element["marshmallow_field"])
-        
+
         # get discriminator field name and oneof schemas
-        self.discriminator = element.get("discriminator", "type") 
+        self.discriminator = element.get("discriminator", "type")
         self.oneof_schemas = element.get("oneof", [])
-        
+
         # create child data types for each oneof schema
         for oneof_item in self.oneof_schemas:
             discriminator_value = oneof_item.get("discriminator")
             schema_type = oneof_item.get("type")
-            
+
             if discriminator_value and schema_type:
                 schema_def = self._registry.get_type(schema_type)
                 self.polymorphic_children[discriminator_value] = schema_def
-        
-        # create a custom polymorphic field        
+
+        # create a custom polymorphic field
         return PolymorphicField(
             discriminator=self.discriminator,
             schemas=self._create_schema_fields(field_name, element),
-            **self._get_marshmallow_field_args(field_name, element)
+            **self._get_marshmallow_field_args(field_name, element),
         )
-    
+
     def _create_schema_fields(
         self, field_name: str, element: dict[str, Any]
     ) -> dict[str, ma.fields.Field]:
         """
         Create marshmallow fields for each schema variant.
         """
-        
+
         schema_fields = {}
-        
+
         for oneof_item in self.oneof_schemas:
             discriminator_value = oneof_item.get("discriminator")
-            
+
             if discriminator_value in self.polymorphic_children:
                 child_datatype = self.polymorphic_children[discriminator_value]
-                schema_fields[discriminator_value] = child_datatype.create_marshmallow_field(
-                    field_name=discriminator_value, 
-                    element={}
+                schema_fields[discriminator_value] = (
+                    child_datatype.create_marshmallow_field(
+                        field_name=discriminator_value, element={}
+                    )
                 )
-                     
-        return schema_fields        
-    
+
+        return schema_fields
+
+    @override
+    def create_ui_marshmallow_fields(
+        self, field_name: str, element: dict[str, Any]
+    ) -> dict[str, ma.fields.Field]:
+        ui_fields = {}
+
+        oneof_schemas = element.get("oneof", [])
+
+        for oneof_item in oneof_schemas:
+            discriminator_value = oneof_item.get("discriminator")
+            schema_type = oneof_item.get("type")
+
+            if discriminator_value and schema_type:
+                schema = self._registry.get_type(schema_type)
+
+                ui_field = schema.create_ui_marshmallow_fields(
+                    field_name=discriminator_value, element=oneof_item
+                )
+                if ui_field:
+                    ui_fields.update(ui_field)
+
+        return {
+            field_name: PolymorphicField(
+                discriminator=self.discriminator, schemas=ui_fields
+            )
+        }
+
     @override
     def create_json_schema(self, element: dict[str, Any]) -> dict[str, Any]:
         """
@@ -80,39 +108,37 @@ class PolymorhicDataType(DataType):
         """
         discriminator = element.get("discriminator", "type")
         oneof_schemas = element.get("oneof", [])
-        
+
         json_one_of_schemas = []
-        
+
         for oneof_item in oneof_schemas:
             discriminator_value = oneof_item.get("discriminator")
             schema_type = oneof_item.get("type")
-            
+
             if discriminator_value and schema_type:
                 schema = self._registry.get_type(schema_type)
                 child_jsonschema = schema.create_json_schema(oneof_item)
-                
+
                 if "properties" not in child_jsonschema:
                     child_jsonschema["properties"] = {}
 
                 child_jsonschema["properties"][discriminator] = {
                     "type": "string",
-                    "const": discriminator_value
+                    "const": discriminator_value,
                 }
-                
+
                 if "required" not in child_jsonschema:
                     child_jsonschema["required"] = []
                 if discriminator not in child_jsonschema["required"]:
                     child_jsonschema["required"].append(discriminator)
-                
+
                 json_one_of_schemas.append(child_jsonschema)
-        
+
         return {
             "oneOf": json_one_of_schemas,
-            "discriminator": {
-                "propertyName": discriminator
-            }
-        }         
-    
+            "discriminator": {"propertyName": discriminator},
+        }
+
     @override
     def create_mapping(self, element: dict[str, Any]) -> dict[str, Any]:
         """
@@ -122,54 +148,46 @@ class PolymorhicDataType(DataType):
         discriminator = element.get("discriminator", "type")
         oneof_schemas = element.get("oneof", [])
 
-        all_properties = {
-            discriminator: {
-                "type": "keyword"
-            }
-        }
-        
+        all_properties = {discriminator: {"type": "keyword"}}
+
         for oneof_item in oneof_schemas:
             discriminator_value = oneof_item.get("discriminator")
             schema_type = oneof_item.get("type")
-            
+
             if discriminator_value and schema_type:
                 schema = self._registry.get_type(schema_type)
                 child_mapping = schema.create_mapping(oneof_item)
-               
+
                 if "properties" in child_mapping:
                     all_properties.update(child_mapping["properties"])
-                    
-        return {
-            "type": "object",
-            "properties": all_properties
-        }             
-        
-        
-        
+
+        return {"type": "object", "properties": all_properties}
+
+
 class PolymorphicField(ma.fields.Field):
-    def __init__(self, discriminator: str, schemas: dict[str, ma.fields.Field], *args, **kwargs):
+    def __init__(
+        self, discriminator: str, schemas: dict[str, ma.fields.Field], *args, **kwargs
+    ):
         super().__init__(*args, **kwargs)
         self.discriminator = discriminator
         self.schemas = schemas
-    
+
     def _serialize(self, value: Any, attr: str, obj: Any, **kwargs) -> Any:
         if not isinstance(value, dict):
             return value
-        
+
         discriminator_value = value.get(self.discriminator)
         if discriminator_value in self.schemas:
             schema_field = self.schemas[discriminator_value]
             return schema_field._serialize(value, attr, obj, **kwargs)
-        
-        return value    
-    
+
+        return value
+
     def _deserialize(self, value, attr, data, **kwargs):
         discriminator_value = value.get(self.discriminator)
-        
+
         if discriminator_value not in self.schemas:
-            self.fail('unknown_type', type=discriminator_value)
-            
+            self.fail("unknown_type", type=discriminator_value)
+
         schema_field = self.schemas[discriminator_value]
-        return schema_field._deserialize(value, attr, data, **kwargs)   
-                
-    
+        return schema_field._deserialize(value, attr, data, **kwargs)

--- a/src/oarepo_model/datatypes/polymorphic.py
+++ b/src/oarepo_model/datatypes/polymorphic.py
@@ -166,7 +166,6 @@ class PolymorphicDataType(DataType):
 
         return {
             "oneOf": json_one_of_schemas,
-            "discriminator": {"propertyName": discriminator},
         }
 
     @override

--- a/src/oarepo_model/datatypes/polymorphic.py
+++ b/src/oarepo_model/datatypes/polymorphic.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import Any, override
+
+import marshmallow as ma
+import marshmallow_oneofschema
+from invenio_base.utils import obj_or_import_string
+
+from .base import DataType
+
+
+class PolymorhicDataType(DataType):
+    """
+    Data type for handling polymorphic schemas with discriminator fields.
+    This allows for fields that can be one of several different types based on a discriminator field.
+    """
+    
+    TYPE = "polymorphic"
+    
+    marshmallow_field_class = marshmallow_oneofschema.OneOfSchema
+    jsonschema_type = "" # TODO
+    mapping_type = {} # TODO
+    
+    def __init__(self, registry, name = None):
+        super().__init__(registry, name)
+        self.discriminator: str = "type"
+        self.oneof_schemas: list[dict[str, Any]] = []
+        self.polymorphic_children: dict[str, DataType] = {}
+    
+    @override
+    def create_marshmallow_field(self, field_name, element) -> ma.fields.Field:
+        """
+        Create a Marshmallow field for polymorphic data type.
+        Uses OneOf field with different schemas based on discriminator.
+        """
+        
+        if element.get("marshmallow_field") is not None:
+            return obj_or_import_string(element["marshmallow_field"])
+        
+        # get discriminator field name and oneof schemas
+        self.discriminator = element.get("discriminator", "type") 
+        self.oneof_schemas = element.get("oneof", [])
+        
+        # create child data types for each oneof schema
+        for oneof_item in self.oneof_schemas:
+            discriminator_value = oneof_item.get("discriminator")
+            schema_type = oneof_item.get("type")
+            
+            if discriminator_value and schema_type:
+                schema_def = self._registry.get_type(schema_type)
+                self.polymorphic_children[discriminator_value] = schema_def
+        
+        # create a custom polymorphic field        
+        return PolymorphicField(
+            discriminator=self.discriminator,
+            schemas=self._create_schema_fields(field_name, element),
+            **self._get_marshmallow_field_args(field_name, element)
+        )
+    
+    def _create_schema_fields(
+        self, field_name: str, element: dict[str, Any]
+    ) -> dict[str, ma.fields.Field]:
+        """
+        Create marshmallow fields for each schema variant.
+        """
+        
+        schema_fields = {}
+        
+        for oneof_item in self.oneof_schemas:
+            discriminator_value = oneof_item.get("discriminator")
+            
+            if discriminator_value in self.polymorphic_children:
+                child_datatype = self.polymorphic_children[discriminator_value]
+                schema_fields[discriminator_value] = child_datatype.create_marshmallow_field(
+                    field_name=discriminator_value, 
+                    element={}
+                )
+                     
+        return schema_fields        
+        
+class PolymorphicField(ma.fields.Field):
+    def __init__(self, discriminator: str, schemas: dict[str, ma.fields.Field], *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.discriminator = discriminator
+        self.schemas = schemas
+    
+    def _serialize(self, value: Any, attr: str, obj: Any, **kwargs) -> Any:
+        if not isinstance(value, dict):
+            return value
+        
+        discriminator_value = value.get(self.discriminator)
+        if discriminator_value in self.schemas:
+            schema_field = self.schemas[discriminator_value]
+            return schema_field._serialize(value, attr, obj, **kwargs)
+        
+        return value    
+    
+    def _deserialize(self, value, attr, data, **kwargs):
+        discriminator_value = value.get(self.discriminator)
+        
+        if discriminator_value not in self.schemas:
+            self.fail('unknown_type', type=discriminator_value)
+            
+        schema_field = self.schemas[discriminator_value]
+        return schema_field._deserialize(value, attr, data, **kwargs)   
+                
+    

--- a/src/oarepo_model/datatypes/polymorphic.py
+++ b/src/oarepo_model/datatypes/polymorphic.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, override
 
 import marshmallow as ma
+from deepmerge import always_merger
 from invenio_base.utils import obj_or_import_string
 from marshmallow.utils import get_value
 from marshmallow.utils import (
@@ -192,7 +193,9 @@ class PolymorphicDataType(DataType):
 
                 # dump all properties from all variants in 1 dictionary
                 if "properties" in child_mapping:
-                    all_properties.update(child_mapping["properties"])
+                    all_properties = always_merger.merge(
+                        all_properties, child_mapping["properties"]
+                    )
 
         return {"type": "object", "properties": all_properties}
 

--- a/tests/datatypes/test_schemas.py
+++ b/tests/datatypes/test_schemas.py
@@ -600,7 +600,6 @@ def test_polymorphic_field_json_schema(test_schema):
                 "required": ["type"],
             },
         ],
-        "discriminator": {"propertyName": "type"},
     }
 
     print()

--- a/tests/datatypes/test_schemas.py
+++ b/tests/datatypes/test_schemas.py
@@ -455,6 +455,36 @@ def test_polymorphic_field(test_schema):
         schema.load(val)
 
 
+def test_polymorphic_field_required(test_schema):
+    person_schema = {
+        "type": "object",
+        "properties": {"first_name": {"type": "fulltext"}, "type": {"type": "keyword"}},
+    }
+    organization_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "fulltext+keyword"},
+            "type": {"type": "keyword"},
+        },
+    }
+
+    schema = test_schema(
+        {
+            "type": "polymorphic",
+            "discriminator": "type",
+            "oneof": [
+                {"discriminator": "person", "type": "Person"},
+                {"discriminator": "organization", "type": "Organization"},
+            ],
+            "required": True,
+        },
+        extra_types={"Person": person_schema, "Organization": organization_schema},
+    )
+    with pytest.raises(ma.ValidationError):
+        val = {}  # missing data
+        assert schema.load(val) == val
+
+
 def test_polymorphic_field_in_array(test_schema):
     person_schema = {
         "type": "object",

--- a/tests/datatypes/test_schemas.py
+++ b/tests/datatypes/test_schemas.py
@@ -272,53 +272,53 @@ def test_forwarded_object_schema(test_schema):
     with pytest.raises(ma.ValidationError):
         schema.load({"a": {"name": "John", "age": -5}})
 
+
 def test_date_field(test_schema):
     schema = test_schema(
-        {
-            "type": "date",
-            "min_date": date(2023, 1, 1),
-            "max_date": date(2023, 12, 31)    
-        }
+        {"type": "date", "min_date": date(2023, 1, 1), "max_date": date(2023, 12, 31)}
     )
-    
+
     assert schema.load({"a": "2023-01-02"}) == {"a": date(2023, 1, 2)}
-    
+
     with pytest.raises(ma.ValidationError):
         schema.load({"a": "01/01/2023"})  # wrong format
 
     with pytest.raises(ma.ValidationError):
-        schema.load({"a": 1234}) # not a date
-    
+        schema.load({"a": 1234})  # not a date
+
     with pytest.raises(ma.ValidationError):
         schema.load({"a": "2022-12-31"})
 
     with pytest.raises(ma.ValidationError):
-        schema.load({"a": "2024-01-01"})    
-        
+        schema.load({"a": "2024-01-01"})
+
+
 def test_datetime_field(test_schema):
-    schema = test_schema({
-        "type": "datetime",
-        "min_datetime": datetime(2023, 1, 1, 0, 0, 0),
-        "max_datetime": datetime(2023, 12, 31, 23, 59, 59)    
-    })
+    schema = test_schema(
+        {
+            "type": "datetime",
+            "min_datetime": datetime(2023, 1, 1, 0, 0, 0),
+            "max_datetime": datetime(2023, 12, 31, 23, 59, 59),
+        }
+    )
 
     assert schema.load({"a": "2023-01-01T12:30:00"}) == {
         "a": datetime(2023, 1, 1, 12, 30, 0)
     }
-    
+
     assert schema.load({"a": "2023-01-01 12:30:00"}) == {
         "a": datetime(2023, 1, 1, 12, 30, 0)
-    }     
-    
-    with pytest.raises(ma.ValidationError):
-         assert schema.load({"a": "01/12/2022 14:15:00"}) # wrong format
-         
-    with pytest.raises(ma.ValidationError):
-        schema.load({"a": "2022-12-31T23:59:59"}) # out of bounds
+    }
 
     with pytest.raises(ma.ValidationError):
-        schema.load({"a": "2024-01-01T00:00:00"})    # out of bounds  
-     
+        assert schema.load({"a": "01/12/2022 14:15:00"})  # wrong format
+
+    with pytest.raises(ma.ValidationError):
+        schema.load({"a": "2022-12-31T23:59:59"})  # out of bounds
+
+    with pytest.raises(ma.ValidationError):
+        schema.load({"a": "2024-01-01T00:00:00"})  # out of bounds
+
 
 def test_time_field(test_schema):
     schema = test_schema(
@@ -333,18 +333,17 @@ def test_time_field(test_schema):
 
     with pytest.raises(ma.ValidationError):
         schema.load({"a": "08:59:59"})
-        
+
     with pytest.raises(ma.ValidationError):
         schema.load({"a": "01.02.2023"})
-    
+
     with pytest.raises(ma.ValidationError):
         schema.load({"a": "2024-01-01T00:00:00"})
-    
 
     with pytest.raises(ma.ValidationError):
         schema.load({"a": "17:00:01"})
-        
-        
+
+
 def test_edtf_time_field(test_schema):
     schema = test_schema(
         {
@@ -354,20 +353,20 @@ def test_edtf_time_field(test_schema):
 
     val = "2023"
     assert schema.load({"a": val}) == {"a": val}
-    
+
     val = "2023-01-01"
     assert schema.load({"a": val}) == {"a": val}
 
     val = "2024-01-01T00:00:00"
     assert schema.load({"a": val}) == {"a": val}
-        
+
     with pytest.raises(ma.ValidationError):
-        schema.load({"a": 2023})      
-        
-    with pytest.raises(ma.ValidationError):    
-        schema.load({"a":"12:00:00Z/13:00:00Z" })    
-        
-        
+        schema.load({"a": 2023})
+
+    with pytest.raises(ma.ValidationError):
+        schema.load({"a": "12:00:00Z/13:00:00Z"})
+
+
 def test_edtf_field(test_schema):
     schema = test_schema(
         {
@@ -378,16 +377,15 @@ def test_edtf_field(test_schema):
     val = "2023-01-01"
     assert schema.load({"a": val}) == {"a": val}
 
-    
-    with pytest.raises(ma.ValidationError):   
+    with pytest.raises(ma.ValidationError):
         val = "2023/2025"
-        schema.load({"a": val}) 
-        
-    with pytest.raises(ma.ValidationError):   
+        schema.load({"a": val})
+
+    with pytest.raises(ma.ValidationError):
         val = "2024-01-01T00:00:00"
         schema.load({"a": val})
-    
-        
+
+
 def test_edtf_interval_field(test_schema):
     schema = test_schema(
         {
@@ -397,16 +395,16 @@ def test_edtf_interval_field(test_schema):
 
     val = "1964/2008"
     assert schema.load({"a": val}) == {"a": val}
-    
+
     val = "2004-06/2006-08"
     assert schema.load({"a": val}) == {"a": val}
-    
+
     val = "2004-02-01/2005-02-08"
     assert schema.load({"a": val}) == {"a": val}
-    
+
     val = "2004-02-01/2005"
     assert schema.load({"a": val}) == {"a": val}
-    
+
     val = "2005/2006-02"
     assert schema.load({"a": val}) == {"a": val}
 
@@ -418,7 +416,10 @@ def test_polymorphic_field(test_schema):
     }
     organization_schema = {
         "type": "object",
-        "properties": {"name": {"type": "fulltext+keyword"}, "type": {"type": "keyword"}},
+        "properties": {
+            "name": {"type": "fulltext+keyword"},
+            "type": {"type": "keyword"},
+        },
     }
 
     schema = test_schema(
@@ -426,8 +427,8 @@ def test_polymorphic_field(test_schema):
             "type": "polymorphic",
             "discriminator": "type",
             "oneof": [
-                {"discriminator":"person", "type": "Person"},
-                {"discriminator":"organization", "type": "Organization"}
+                {"discriminator": "person", "type": "Person"},
+                {"discriminator": "organization", "type": "Organization"},
             ],
         },
         extra_types={"Person": person_schema, "Organization": organization_schema},
@@ -435,14 +436,215 @@ def test_polymorphic_field(test_schema):
 
     val = {"a": {"type": "person", "first_name": "bob"}}
     assert schema.load(val) == val
-    
+
     val = {"a": {"type": "organization", "name": "org name"}}
     assert schema.load(val) == val
-    
+
     with pytest.raises(ma.ValidationError):
         val = {"a": {"type": "person", "name": "bob"}}
         schema.load(val)
-    
+
     with pytest.raises(ma.ValidationError):
         val = {"a": {"type": "organization", "first_name": "org name"}}
         schema.load(val)
+
+    with pytest.raises(ma.ValidationError):
+        val = {
+            "a": {"type": "organization", "name": "org name", "full_name": "full_name"}
+        }
+        schema.load(val)
+
+
+def test_polymorphic_field_in_array(test_schema):
+    person_schema = {
+        "type": "object",
+        "properties": {"first_name": {"type": "fulltext"}, "type": {"type": "keyword"}},
+    }
+    organization_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "fulltext+keyword"},
+            "type": {"type": "keyword"},
+        },
+    }
+
+    schema = test_schema(
+        {
+            "type": "array",
+            "items": {
+                "type": "polymorphic",
+                "discriminator": "type",
+                "oneof": [
+                    {"discriminator": "person", "type": "Person"},
+                    {"discriminator": "organization", "type": "Organization"},
+                ],
+            },
+        },
+        extra_types={"Person": person_schema, "Organization": organization_schema},
+    )
+
+    val = {"a": [{"type": "person", "first_name": "bob"}]}
+    assert schema.load(val) == val
+
+    val = {"a": [{"type": "organization", "name": "org name"}]}
+    assert schema.load(val) == val
+
+    val = {
+        "a": [
+            {"type": "person", "first_name": "bob"},
+            {"type": "person", "first_name": "bob2"},
+            {"type": "organization", "name": "org name"},
+            {"type": "organization", "name": "org name2"},
+        ]
+    }
+    assert schema.load(val) == val
+
+    with pytest.raises(ma.ValidationError):
+        val = {"a": [{"type": "person", "name": "bob"}]}
+        schema.load(val)
+
+    with pytest.raises(ma.ValidationError):
+        val = {"a": [{"type": "organization", "first_name": "org name"}]}
+        schema.load(val)
+
+    with pytest.raises(ma.ValidationError):
+        val = {
+            "a": [
+                {"type": "organization", "name": "org name", "full_name": "full_name"}
+            ]
+        }
+        schema.load(val)
+
+
+def test_polymorphic_field_json_schema(test_schema):
+    from oarepo_model.datatypes.registry import DataTypeRegistry
+
+    datatype_registry = DataTypeRegistry()
+    datatype_registry.load_entry_points()
+
+    person_schema = {
+        "type": "object",
+        "properties": {"first_name": {"type": "fulltext"}, "type": {"type": "keyword"}},
+    }
+    organization_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "fulltext+keyword"},
+            "type": {"type": "keyword"},
+        },
+    }
+    polymorphic_schema = {
+        "type": "polymorphic",
+        "discriminator": "type",
+        "oneof": [
+            {"discriminator": "person", "type": "Person"},
+            {"discriminator": "organization", "type": "Organization"},
+        ],
+    }
+
+    extra_types = {"Person": person_schema, "Organization": organization_schema}
+    datatype_registry.add_types(extra_types)
+
+    ret = datatype_registry.get_type("polymorphic").create_json_schema(
+        element=polymorphic_schema
+    )
+
+    assert ret == {
+        "oneOf": [
+            {
+                "type": "object",
+                "unevaluatedProperties": False,
+                "properties": {
+                    "first_name": {"type": "string"},
+                    "type": {"type": "string", "const": "person"},
+                },
+                "required": ["type"],
+            },
+            {
+                "type": "object",
+                "unevaluatedProperties": False,
+                "properties": {
+                    "name": {"type": "string"},
+                    "type": {"type": "string", "const": "organization"},
+                },
+                "required": ["type"],
+            },
+        ],
+        "discriminator": {"propertyName": "type"},
+    }
+
+    print()
+
+
+def test_polymorphic_field_mapping(test_schema):
+    from oarepo_model.datatypes.registry import DataTypeRegistry
+
+    datatype_registry = DataTypeRegistry()
+    datatype_registry.load_entry_points()
+
+    person_schema = {
+        "type": "object",
+        "properties": {"first_name": {"type": "fulltext"}, "type": {"type": "keyword"}},
+    }
+    organization_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "fulltext+keyword"},
+            "type": {"type": "keyword"},
+        },
+    }
+    polymorphic_schema = {
+        "type": "polymorphic",
+        "discriminator": "type",
+        "oneof": [
+            {"discriminator": "person", "type": "Person"},
+            {"discriminator": "organization", "type": "Organization"},
+        ],
+    }
+
+    extra_types = {"Person": person_schema, "Organization": organization_schema}
+    datatype_registry.add_types(extra_types)
+
+    ret = datatype_registry.get_type("polymorphic").create_mapping(
+        element=polymorphic_schema
+    )
+
+    # 2 keys on top level -> type and properties
+    assert ret.keys() == {"type", "properties"}
+
+    # type is object
+    assert ret["type"] == "object"
+
+    # properties has all fields from polymorphic field (from person and organization)
+    assert ret["properties"].keys() == {
+        "type",  # discriminator
+        "first_name",  # from person
+        "name",  # from org
+    }
+
+    polymorphic_schema_in_array = {
+        "type": "array",
+        "items": {
+            "type": "polymorphic",
+            "discriminator": "type",
+            "oneof": [
+                {"discriminator": "person", "type": "Person"},
+                {"discriminator": "organization", "type": "Organization"},
+            ],
+        },
+    }
+    ret = datatype_registry.get_type("array").create_mapping(
+        element=polymorphic_schema_in_array
+    )
+    # 2 keys on top level -> type and properties
+    assert ret.keys() == {"type", "properties"}
+
+    # type is object
+    assert ret["type"] == "object"
+
+    # properties has all fields from polymorphic field (from person and organization)
+    assert ret["properties"].keys() == {
+        "type",  # discriminator
+        "first_name",  # from person
+        "name",  # from org
+    }

--- a/tests/datatypes/test_ui_schemas.py
+++ b/tests/datatypes/test_ui_schemas.py
@@ -1,10 +1,11 @@
+from datetime import time
 from typing import Any, Callable
 
-from datetime import time
 import marshmallow as ma
 import pytest
-from flask_babel import get_locale
 from babel.numbers import format_decimal
+from flask_babel import get_locale
+
 
 @pytest.fixture
 def test_ui_schema(datatype_registry) -> Callable[[dict[str, Any]], ma.Schema]:
@@ -92,7 +93,7 @@ def test_numbers_ui_schema(test_ui_schema):
             "type": "int",
         }
     )
-    
+
     loc = str(get_locale()) if get_locale() else None
     val = format_decimal(1000000, locale=loc)
     assert schema.dump({"a": 1000000}) == {"a": val}
@@ -162,7 +163,7 @@ def test_array_ui_ints(test_ui_schema):
     val2 = format_decimal(10000, locale=loc)
     res = schema.dump({"a": [123.456, 10000]})
     assert res == {"a": [val1, val2]}
-    
+
     res = schema.dump({"a": []})
     assert res == {"a": []}
 
@@ -179,7 +180,7 @@ def test_array_ui_bools(test_ui_schema):
 
     res = schema.dump({"a": [True, True, False]})
     assert res == {"a": ["true", "true", "false"]}
-    
+
     res = schema.dump({"a": []})
     assert res == {"a": []}
 
@@ -392,59 +393,71 @@ def test_ui_every_format_in_object(test_ui_schema):
         }
     )
 
-    assert res == {
-        "a": {
-            # no string formatting -> name is left out
-            "age": "30", # age is formatted but same key name is kept
-            "height": "1.82",  # height is formatted but same key name is kept
-            "date_l10n_long": "December 31, 2023", # 4 different formats for the specific date
-            "date_l10n_medium": "Dec 31, 2023",    # new key has prefix of an original key name
-            "date_l10n_short": "12/31/23",
-            "date_l10n_full": "Sunday, December 31, 2023",
-            "some_other_date_l10n_long": "December 31, 2023", # 4 different formats for the another specific date 
-            "some_other_date_l10n_medium": "Dec 31, 2023",    # new key has prefix of an original key name
-            "some_other_date_l10n_short": "12/31/23",
-            "some_other_date_l10n_full": "Sunday, December 31, 2023",
-            "is_draft_i18n": "true", # boolean is formatted always with i18n suffix
-            "arrays": {
-                "array_bool": ["true"], # bools in arrays are just transformed individually a placed in array
-                "array_int": ["1"], # numbers in arrays are just transformed individually a placed in array
-                "array_float": ["1.1"],
-                "array_date": [ # each date has 4 transformations, so dictionary is created for each original date
+    assert (
+        res
+        == {
+            "a": {
+                # no string formatting -> name is left out
+                "age": "30",  # age is formatted but same key name is kept
+                "height": "1.82",  # height is formatted but same key name is kept
+                "date_l10n_long": "December 31, 2023",  # 4 different formats for the specific date
+                "date_l10n_medium": "Dec 31, 2023",  # new key has prefix of an original key name
+                "date_l10n_short": "12/31/23",
+                "date_l10n_full": "Sunday, December 31, 2023",
+                "some_other_date_l10n_long": "December 31, 2023",  # 4 different formats for the another specific date
+                "some_other_date_l10n_medium": "Dec 31, 2023",  # new key has prefix of an original key name
+                "some_other_date_l10n_short": "12/31/23",
+                "some_other_date_l10n_full": "Sunday, December 31, 2023",
+                "is_draft_i18n": "true",  # boolean is formatted always with i18n suffix
+                "arrays": {
+                    "array_bool": [
+                        "true"
+                    ],  # bools in arrays are just transformed individually a placed in array
+                    "array_int": [
+                        "1"
+                    ],  # numbers in arrays are just transformed individually a placed in array
+                    "array_float": ["1.1"],
+                    "array_date": [  # each date has 4 transformations, so dictionary is created for each original date
+                        {
+                            "item_l10n_long": "January 1, 2023",
+                            "item_l10n_medium": "Jan 1, 2023",
+                            "item_l10n_short": "1/1/23",
+                            "item_l10n_full": "Sunday, January 1, 2023",
+                        }
+                    ],
+                },
+                "array_of_objects": [
                     {
-                        "item_l10n_long": "January 1, 2023",
-                        "item_l10n_medium": "Jan 1, 2023",
-                        "item_l10n_short": "1/1/23",
-                        "item_l10n_full": "Sunday, January 1, 2023",
-                    }
+                        # name is left out -> no ui representation
+                        "measurements": [
+                            "123",
+                            "456",
+                            "789",
+                            "123.456",
+                        ],  # numbers in arrays are just transformed individually a placed in array
+                        "birthday_l10n_long": "December 31, 2023",  # just testing nested structures, same logic as above
+                        "birthday_l10n_medium": "Dec 31, 2023",
+                        "birthday_l10n_short": "12/31/23",
+                        "birthday_l10n_full": "Sunday, December 31, 2023",
+                    },
+                    {
+                        "measurements": [],  # testing empty arrays
+                        "birthday_l10n_long": "December 30, 2023",
+                        "birthday_l10n_medium": "Dec 30, 2023",
+                        "birthday_l10n_short": "12/30/23",
+                        "birthday_l10n_full": "Saturday, December 30, 2023",
+                    },
+                    {
+                        "measurements": ["123"],
+                        "birthday_l10n_long": "December 29, 2023",
+                        "birthday_l10n_medium": "Dec 29, 2023",
+                        "birthday_l10n_short": "12/29/23",
+                        "birthday_l10n_full": "Friday, December 29, 2023",
+                    },
                 ],
-            },
-            "array_of_objects": [
-                {
-                    # name is left out -> no ui representation
-                    "measurements": ["123", "456", "789", "123.456"], # numbers in arrays are just transformed individually a placed in array 
-                    "birthday_l10n_long": "December 31, 2023", # just testing nested structures, same logic as above
-                    "birthday_l10n_medium": "Dec 31, 2023",
-                    "birthday_l10n_short": "12/31/23",
-                    "birthday_l10n_full": "Sunday, December 31, 2023",
-                },
-                {
-                    "measurements": [], # testing empty arrays
-                    "birthday_l10n_long": "December 30, 2023",
-                    "birthday_l10n_medium": "Dec 30, 2023",
-                    "birthday_l10n_short": "12/30/23",
-                    "birthday_l10n_full": "Saturday, December 30, 2023",
-                },
-                {
-                    "measurements": ["123"], 
-                    "birthday_l10n_long": "December 29, 2023",
-                    "birthday_l10n_medium": "Dec 29, 2023",
-                    "birthday_l10n_short": "12/29/23",
-                    "birthday_l10n_full": "Friday, December 29, 2023",
-                },
-            ],
+            }
         }
-    }
+    )
 
     # there are 4 UI representation of a date in UI, all should be there
     assert "date_l10n_long" in res["a"]
@@ -483,7 +496,7 @@ def test_ui_every_format_in_object(test_ui_schema):
             }
         }
     )
-    # same logic as above, just more tests 
+    # same logic as above, just more tests
     assert res == {
         "a": {
             "age": "30",
@@ -517,5 +530,195 @@ def test_ui_every_format_in_object(test_ui_schema):
                 ],
             },
             "array_of_objects": [],
+        }
+    }
+
+
+def test_polymorphic_ui_schema(test_ui_schema):
+    person_schema = {
+        "type": "object",
+        "properties": {
+            "first_name": {"type": "fulltext"},
+            "type": {"type": "keyword"},
+            "age": {"type": "int"},
+            "isActive": {"type": "boolean"},
+        },
+    }
+    organization_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "fulltext+keyword"},
+            "type": {"type": "keyword"},
+            "age": {"type": "int"},
+            "isFree": {"type": "boolean"},
+        },
+    }
+
+    schema = test_ui_schema(
+        {
+            "type": "polymorphic",
+            "discriminator": "type",
+            "oneof": [
+                {"discriminator": "person", "type": "Person"},
+                {"discriminator": "organization", "type": "Organization"},
+            ],
+        },
+        extra_types={"Person": person_schema, "Organization": organization_schema},
+    )
+
+    val = {"a": {"type": "person", "first_name": "bob", "age": 123, "isActive": True}}
+    ret = schema.dump(val)
+    assert ret == {
+        "a": {"age": "123", "isActive_i18n": "true"}
+    }  # strings are removed, number and boolean are transformed
+
+    val = {"a": {"type": "organization", "name": "CVUT", "age": 100000, "isFree": True}}
+    ret = schema.dump(val)
+    assert ret == {
+        "a": {"age": "100,000", "isFree_i18n": "true"}
+    }  # strings are removed, number and boolean are transformed
+
+
+def test_polymorphic_ui_schema_in_array(test_ui_schema):
+    person_schema = {
+        "type": "object",
+        "properties": {
+            "first_name": {"type": "fulltext"},
+            "type": {"type": "keyword"},
+            "age": {"type": "int"},
+            "isActive": {"type": "boolean"},
+        },
+    }
+    organization_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "fulltext+keyword"},
+            "type": {"type": "keyword"},
+            "age": {"type": "int"},
+            "isFree": {"type": "boolean"},
+        },
+    }
+
+    schema = test_ui_schema(
+        {
+            "type": "array",
+            "items": {
+                "type": "polymorphic",
+                "discriminator": "type",
+                "oneof": [
+                    {"discriminator": "person", "type": "Person"},
+                    {"discriminator": "organization", "type": "Organization"},
+                ],
+            },
+        },
+        extra_types={"Person": person_schema, "Organization": organization_schema},
+    )
+    loc = str(get_locale()) if get_locale() else None
+
+    # ---------------- 1 item in array ----------------------------
+    val = {"a": [{"type": "person", "first_name": "bob", "age": 123, "isActive": True}]}
+    formatted_number = format_decimal(123, locale=loc)
+    ret = schema.dump(val)
+    assert ret == {
+        "a": [{"age": formatted_number, "isActive_i18n": "true"}]
+    }  # strings are removed, number and boolean are transformed
+    # -------------------------------------------------------------
+
+    # ---------------- 1 item in array ----------------------------
+    val = {
+        "a": [{"type": "organization", "name": "CVUT", "age": 100000, "isFree": True}]
+    }
+    ret = schema.dump(val)
+    formatted_number = format_decimal(100000, locale=loc)
+    assert ret == {
+        "a": [{"age": formatted_number, "isFree_i18n": "true"}]
+    }  # strings are removed, number and boolean are transformed
+    # -------------------------------------------------------------
+
+    # ---------------- multiple items in array --------------------
+    val = {
+        "a": [
+            {"type": "person", "first_name": "bob", "age": 123, "isActive": True},
+            {"type": "person", "first_name": "bob2", "age": 0, "isActive": False},
+            {"type": "organization", "name": "MIT", "age": 666, "isFree": False},
+            {"type": "organization", "name": "Standford", "age": 1337, "isFree": False},
+        ]
+    }
+    formatted_number1 = format_decimal(123, locale=loc)
+    formatted_number2 = format_decimal(0, locale=loc)
+    formatted_number3 = format_decimal(666, locale=loc)
+    formatted_number4 = format_decimal(1337, locale=loc)
+    ret = schema.dump(val)
+    assert ret == {
+        "a": [
+            {"age": formatted_number1, "isActive_i18n": "true"},
+            {"age": formatted_number2, "isActive_i18n": "false"},
+            {"age": formatted_number3, "isFree_i18n": "false"},
+            {"age": formatted_number4, "isFree_i18n": "false"},
+        ]
+    }
+    # -------------------------------------------------------------
+
+
+def test_polymorphic_ui_schema_in_obj(test_ui_schema):
+    person_schema = {
+        "type": "object",
+        "properties": {
+            "first_name": {"type": "fulltext"},
+            "type": {"type": "keyword"},
+            "age": {"type": "int"},
+            "isActive": {"type": "boolean"},
+        },
+    }
+    organization_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "fulltext+keyword"},
+            "type": {"type": "keyword"},
+            "age": {"type": "int"},
+            "isFree": {"type": "boolean"},
+        },
+    }
+
+    schema = test_ui_schema(
+        {
+            "type": "object",
+            "properties": {
+                "publication_date": {"type": "date"},
+                "supported_by": {
+                    "type": "polymorphic",
+                    "discriminator": "type",
+                    "oneof": [
+                        {"discriminator": "person", "type": "Person"},
+                        {"discriminator": "organization", "type": "Organization"},
+                    ],
+                },
+            },
+        },
+        extra_types={"Person": person_schema, "Organization": organization_schema},
+    )
+    loc = str(get_locale()) if get_locale() else None
+
+    val = {
+        "a": {
+            "publication_date": "2023-12-31",
+            "supported_by": {
+                "type": "organization",
+                "name": "CVUT",
+                "age": 100,
+                "isFree": True,
+            },
+        }
+    }
+
+    ret = schema.dump(val)
+    formatted_number = format_decimal(100, locale=loc)
+    assert ret == {
+        "a": {
+            "publication_date_l10n_long": "December 31, 2023",
+            "publication_date_l10n_medium": "Dec 31, 2023",
+            "publication_date_l10n_short": "12/31/23",
+            "publication_date_l10n_full": "Sunday, December 31, 2023",
+            "supported_by": {"age": formatted_number, "isFree_i18n": "true"},
         }
     }

--- a/tests/datatypes/test_ui_schemas.py
+++ b/tests/datatypes/test_ui_schemas.py
@@ -565,17 +565,20 @@ def test_polymorphic_ui_schema(test_ui_schema):
         },
         extra_types={"Person": person_schema, "Organization": organization_schema},
     )
+    loc = str(get_locale()) if get_locale() else None
 
     val = {"a": {"type": "person", "first_name": "bob", "age": 123, "isActive": True}}
     ret = schema.dump(val)
+    formatted_number = format_decimal(123, locale=loc)
     assert ret == {
-        "a": {"age": "123", "isActive_i18n": "true"}
+        "a": {"age": formatted_number, "isActive_i18n": "true"}
     }  # strings are removed, number and boolean are transformed
 
     val = {"a": {"type": "organization", "name": "CVUT", "age": 100000, "isFree": True}}
     ret = schema.dump(val)
+    formatted_number = format_decimal(100000, locale=loc)
     assert ret == {
-        "a": {"age": "100,000", "isFree_i18n": "true"}
+        "a": {"age": formatted_number, "isFree_i18n": "true"}
     }  # strings are removed, number and boolean are transformed
 
 


### PR DESCRIPTION
Data type for handling polymorphic schemas with discriminator fields.
This allows for fields that can be one of several different types based on a discriminator field.

Supports schemas with a 'oneof' array where each item specifies a discriminator value
and corresponding schema type. The discriminator field determines which schema variant
to use for validation and serialization.

Written functions to generate JSON schema, mapping for search and UI fields.

JSON schema follows oneOf design, similar to this: https://stackoverflow.com/questions/25014650/json-schema-example-for-oneof-objects.

Example:
    This schema will support two types of items (person and organization):
       {
           "type": "polymorphic",
           "discriminator": "type",
           "oneof": [
               {"discriminator": "person", "type": "Person"},
               {"discriminator": "organization", "type": "Organization"}
           ]
       }