### PR TITLE
Add preset for registration of Model Metadata

### DIFF
--- a/src/oarepo_model/datatypes/registry.py
+++ b/src/oarepo_model/datatypes/registry.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
 from .base import DataType
 from .wrapped import WrappedDataType
@@ -93,6 +93,13 @@ class DataTypeRegistry:
         if type_name not in self.types:
             raise KeyError(f"Data type '{type_name}' is not registered.")
         return self.types[type_name]
+
+    def items(self) -> Iterable[tuple[str, DataType]]:
+        """Return the items of the 'types' dictionary.
+
+        :return: key-value tuple pairs of the 'types' dictionary.
+        """
+        return self.types.items()
 
     def _unwind_shortcuts_in_properties(
         self,

--- a/src/oarepo_model/presets/records_resources/__init__.py
+++ b/src/oarepo_model/presets/records_resources/__init__.py
@@ -32,7 +32,7 @@ from .files.record_file_mapping import (
 )
 from .files.record_metadata import RecordMetadataWithFilesPreset
 from .finalizers import FinalizationPreset
-from .model_registration import ModelRegistrationPreset
+from .model_registration import ModelMetadataRegistrationPreset, ModelRegistrationPreset
 from .proxy import ProxyPreset
 from .records.dumper import RecordDumperPreset
 from .records.jsonschema import JSONSchemaPreset
@@ -121,6 +121,7 @@ records_preset: list[type[Preset]] = [
     ApiBlueprintPreset,
     AppBlueprintPreset,
     ModelRegistrationPreset,
+    ModelMetadataRegistrationPreset,
     FinalizationPreset,
 ]
 

--- a/tests/test_model_metadata_registration_presets.py
+++ b/tests/test_model_metadata_registration_presets.py
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see https://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+from __future__ import annotations
+
+from oarepo_model.api import model
+from oarepo_model.presets.records_resources.model_registration import (
+    ModelMetadataRegistrationPreset,
+    ModelRegistrationPreset,
+)
+
+
+def test_model_metadata_registration_presets(
+    app,
+):
+    m = model(
+        name="metadata_load_test_with_model_metadata_registration_presets",
+        version="1.0.0",
+        presets=[
+            ModelRegistrationPreset,
+            ModelMetadataRegistrationPreset,
+        ],
+        types=[
+            {
+                "RecordMetadata": {"properties": {"title": {"type": "TitleType"}}},
+                "TitleType": {
+                    "type": "fulltext+keyword",
+                },
+            },
+        ],
+        metadata_type="RecordMetadata",
+    )
+
+    assert m.oarepo_model_arguments["model_metadata"].record_type is None
+    assert m.oarepo_model_arguments["model_metadata"].metadata_type == "RecordMetadata"
+    assert m.oarepo_model_arguments["model_metadata"].types == {
+        "RecordMetadata": {"properties": {"title": {"type": "TitleType"}}},
+        "TitleType": {"type": "fulltext+keyword"},
+    }


### PR DESCRIPTION
Add preset for registration of Model Metadata consisting of record_type, metadata_type and a dictionary of wrapped dictionary-based types (WrappedDataType).