### PR TITLE
Add imports to model metadata

### DIFF
--- a/src/oarepo_model/customizations/__init__.py
+++ b/src/oarepo_model/customizations/__init__.py
@@ -37,6 +37,7 @@ from .copy_file import CopyFile
 from .high_level import (
     AddDefaultSearchFields,
     AddMetadataExport,
+    AddMetadataImport,
     AddPIDRelation,
     IndexNestedFieldsLimit,
     IndexSettings,
@@ -58,6 +59,7 @@ __all__ = [
     "AddJSONFile",
     "AddList",
     "AddMetadataExport",
+    "AddMetadataImport",
     "AddMixins",
     "AddModule",
     "AddPIDRelation",

--- a/src/oarepo_model/customizations/high_level/__init__.py
+++ b/src/oarepo_model/customizations/high_level/__init__.py
@@ -17,6 +17,7 @@ with simple, declarative interfaces.
 from __future__ import annotations
 
 from .add_export import AddMetadataExport
+from .add_import import AddMetadataImport
 from .add_pid_relation import AddPIDRelation
 from .add_search_fields import AddDefaultSearchFields
 from .index_settings import IndexNestedFieldsLimit, IndexSettings, IndexTotalFieldsLimit
@@ -25,6 +26,7 @@ from .set_permission_policy import SetPermissionPolicy
 __all__ = (
     "AddDefaultSearchFields",
     "AddMetadataExport",
+    "AddMetadataImport",
     "AddPIDRelation",
     "IndexNestedFieldsLimit",
     "IndexSettings",

--- a/src/oarepo_model/customizations/high_level/add_import.py
+++ b/src/oarepo_model/customizations/high_level/add_import.py
@@ -1,0 +1,72 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see http://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""High-level customization for adding metadata Imports to models.
+
+This module provides the AddMetadataImport customization that registers an import
+deserializer.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, override
+
+from oarepo_runtime.api import Import
+
+from ..base import Customization
+
+if TYPE_CHECKING:
+    from flask_babel.speaklater import LazyString
+    from flask_resources.deserializers import DeserializerMixin
+
+    from oarepo_model.builder import InvenioModelBuilder
+    from oarepo_model.model import InvenioModel
+
+
+class AddMetadataImport(Customization):
+    """Customization to add metadata import to the model."""
+
+    modifies = ("imports",)
+
+    def __init__(
+        self,
+        code: str,
+        name: LazyString,
+        mimetype: str,
+        deserializer: DeserializerMixin,
+        description: LazyString,
+        **kwargs: Any,
+    ):
+        """Initialize the AddMetadataImport customization.
+
+        :param code: Code of the import format, used to identify the import format in the URL.
+        :param name: Name of the import format, human-readable.
+        :param description: Description of the import format, human-readable.
+        :param mimetype: MIME type of the import format.
+        :param deserializer: Deserializer used to deserialize from the import format into record.
+        """
+        super().__init__("AddMetadataImport")
+        self._code = code
+        self._name = name
+        self._mimetype = mimetype
+        self._deserializer = deserializer
+        self._description = description
+        self._kwargs = kwargs
+
+    @override
+    def apply(self, builder: InvenioModelBuilder, model: InvenioModel) -> None:
+        imports = builder.get_list("imports")
+        imports.append(
+            Import(
+                code=self._code,
+                name=self._name,
+                mimetype=self._mimetype,
+                description=self._description,
+                deserializer=self._deserializer,
+            )
+        )

--- a/src/oarepo_model/presets/records_resources/__init__.py
+++ b/src/oarepo_model/presets/records_resources/__init__.py
@@ -50,6 +50,8 @@ from .records.relations_dumper_ext import RelationsDumperExtPreset
 from .resources.files.file_resource import FileResourcePreset
 from .resources.files.file_resource_config import FileResourceConfigPreset
 from .resources.records.exports import ExportsPreset
+from .resources.records.imports import ImportsPreset
+from .resources.records.json_deserializer import JSONDeserializerPreset
 from .resources.records.register_ui_json_serializer import (
     RegisterJSONUISerializerPreset,
 )
@@ -114,6 +116,8 @@ records_preset: list[type[Preset]] = [
     MetadataUISchemaPreset,
     # resource layer
     ExportsPreset,
+    ImportsPreset,
+    JSONDeserializerPreset,
     RecordResourcePreset,
     RecordResourceConfigPreset,
     JSONUISerializerPreset,

--- a/src/oarepo_model/presets/records_resources/ext.py
+++ b/src/oarepo_model/presets/records_resources/ext.py
@@ -18,7 +18,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, Protocol, cast, override
 
 from invenio_records_resources import __version__
-from oarepo_runtime.api import Export, Model
+from oarepo_runtime.api import Export, Import, Model
 from oarepo_runtime.config import build_config
 
 from oarepo_model.customizations import (
@@ -162,6 +162,10 @@ class ExtPreset(Preset):
                 return cast("list[Export]", runtime_dependencies.get("exports"))
 
             @property
+            def metadata_imports(self) -> list[Import]:
+                return cast("list[Import]", runtime_dependencies.get("imports"))
+
+            @property
             def model_arguments(self) -> dict[str, Any]:
                 """Model arguments for the extension."""
                 return {
@@ -171,6 +175,7 @@ class ExtPreset(Preset):
                     "resource_config": self.records_resource.config,
                     "resource": self.records_resource,
                     "exports": self.metadata_exports,
+                    "imports": self.metadata_imports,
                 }
 
             def init_config(self, app: Flask) -> None:

--- a/src/oarepo_model/presets/records_resources/resources/records/imports.py
+++ b/src/oarepo_model/presets/records_resources/resources/records/imports.py
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see http://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""Imports preset for records."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast, override
+
+from invenio_i18n import lazy_gettext as _
+from proxytypes import LazyProxy
+
+from oarepo_model.customizations import AddList, AddMetadataImport, Customization
+from oarepo_model.presets import Preset
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from flask_resources import JSONDeserializer
+
+    from oarepo_model.builder import InvenioModelBuilder
+    from oarepo_model.model import InvenioModel
+
+
+class ImportsPreset(Preset):
+    """Preset for record metadata imports."""
+
+    provides = ("imports",)
+
+    @override
+    def apply(
+        self,
+        builder: InvenioModelBuilder,
+        model: InvenioModel,
+        dependencies: dict[str, Any],
+    ) -> Generator[Customization]:
+        runtime_dependencies = builder.get_runtime_dependencies()
+        yield AddList(
+            "imports",
+        )
+        yield AddMetadataImport(
+            code="json",
+            name=_("JSON"),
+            mimetype="application/json",
+            deserializer=cast("JSONDeserializer", LazyProxy(lambda: runtime_dependencies.get("JSONDeserializer")())),
+            description=_("json import"),
+        )

--- a/src/oarepo_model/presets/records_resources/resources/records/json_deserializer.py
+++ b/src/oarepo_model/presets/records_resources/resources/records/json_deserializer.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see http://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""UI JSON serializer preset for Invenio record resources.
+
+This module provides a preset that creates a JSON serializer specifically designed
+for user interface contexts. It includes:
+
+- JSONDeserializerPreset: A preset that provides the JSONDeserializer class
+- JSONDeserializer: A deserializer that uses the RecordUISchema
+  for object serialization and outputs JSON format with UI-specific context
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, override
+
+from flask_resources import JSONDeserializer
+
+from oarepo_model.customizations import AddClass, Customization
+from oarepo_model.presets import Preset
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from oarepo_model.builder import InvenioModelBuilder
+    from oarepo_model.model import InvenioModel
+
+
+class JSONDeserializerPreset(Preset):
+    """Preset for JSON Deserializer."""
+
+    provides = ("JSONDeserializerPreset",)
+
+    @override
+    def apply(
+        self,
+        builder: InvenioModelBuilder,
+        model: InvenioModel,
+        dependencies: dict[str, Any],
+    ) -> Generator[Customization]:
+        yield AddClass("JSONDeserializer", JSONDeserializer)

--- a/tests/api_tests/conftest.py
+++ b/tests/api_tests/conftest.py
@@ -111,6 +111,14 @@ def input_data_with_files_disabled(input_data):
     return data
 
 
+@pytest.fixture
+def csv_row_of_input_data_more_complex() -> bytes:
+    csv_text = """title,some_bool_val,height
+Test,True,123
+"""
+    return csv_text.encode("utf-8")
+
+
 class DefaultHeaders:
     """Default headers for requests."""
 
@@ -120,6 +128,9 @@ class DefaultHeaders:
     }
     ui: ClassVar[dict[str, str]] = {
         "accept": "application/vnd.inveniordm.v1+json",
+    }
+    csv: ClassVar[dict[str, str]] = {
+        "content-type": "text/csv",
     }
 
 

--- a/tests/api_tests/test_imports.py
+++ b/tests/api_tests/test_imports.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see https://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""Tests for record imports."""
+
+from __future__ import annotations
+
+
+def test_imports(
+    app,
+    input_data_more_complex,
+    empty_model,
+    csv_row_of_input_data_more_complex,
+    csv_imports_model,
+    search_clear,
+    location,
+    client,
+    headers,
+):
+    assert {x.code for x in empty_model.imports} == {"json"}
+
+    assert empty_model.RecordResourceConfig().request_body_parsers.keys() == {
+        "application/json",
+    }
+
+    assert any(imp.mimetype == "text/csv" for imp in csv_imports_model.imports), (
+        f"Registered imports: {[(i.code, i.mimetype) for i in csv_imports_model.imports]}"
+    )
+
+    res = client.post("csv-imports-test", headers=headers.csv, data=csv_row_of_input_data_more_complex)
+
+    assert res.status_code == 201, res.get_data(as_text=True)
+
+    assert res.json["metadata"] == input_data_more_complex["metadata"]


### PR DESCRIPTION
Add preset for record metadata imports (to allow extension of request body parsers, based on exports preset).