### PR TITLE
added is_published facet

### DIFF
--- a/src/oarepo_model/presets/drafts/__init__.py
+++ b/src/oarepo_model/presets/drafts/__init__.py
@@ -85,6 +85,7 @@ from .services.files.media_files_record_service_config import (
 from .services.files.no_upload_file_service_config import (
     NoUploadFileServiceConfigPreset,
 )
+from .services.records.draft_facets import DraftFacetsPreset
 from .services.records.parent_record_schema import ParentRecordSchemaPreset
 from .services.records.record_schema import DraftRecordSchemaPreset
 from .services.records.relations import RelationsServiceComponentPreset
@@ -116,6 +117,7 @@ drafts_records_preset: list[type[Preset]] = [
     RelationsServiceComponentPreset,
     ParentRecordSchemaPreset,
     DraftSearchOptionsPreset,
+    DraftFacetsPreset,
     # resource layer
     DraftResourcePreset,
     DraftResourceConfigPreset,

--- a/src/oarepo_model/presets/drafts/services/records/draft_facets.py
+++ b/src/oarepo_model/presets/drafts/services/records/draft_facets.py
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see http://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""Module to generate draft-specific facets."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, override
+
+from oarepo_runtime.services.facets.utils import build_facet
+
+from oarepo_model.customizations import (
+    AddToDictionary,
+    AddToModule,
+    Customization,
+)
+from oarepo_model.presets import Preset
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from oarepo_model.builder import InvenioModelBuilder
+    from oarepo_model.model import InvenioModel
+
+
+class DraftFacetsPreset(Preset):
+    """Preset for draft-specific facets (is_published)."""
+
+    provides = ("DraftFacets",)
+    modifies = ("RecordFacets",)
+
+    @override
+    def apply(
+        self,
+        builder: InvenioModelBuilder,
+        model: InvenioModel,
+        dependencies: dict[str, Any],
+    ) -> Generator[Customization]:
+        draft_facets: dict[str, list[dict[str, str | object]]] = {
+            "is_published": [
+                {
+                    "facet": "invenio_records_resources.services.records.facets.TermsFacet",
+                    "field": "is_published",
+                }
+            ],
+        }
+
+        search_options_facets = {}
+        for facet_name, facet_def in draft_facets.items():
+            yield AddToModule("facets", facet_name, build_facet(facet_def))
+            search_options_facets[facet_name] = build_facet(facet_def)
+
+        yield AddToDictionary("RecordFacets", search_options_facets)

--- a/tests/api_tests/test_facets.py
+++ b/tests/api_tests/test_facets.py
@@ -43,3 +43,17 @@ def test_facet(
     no_hit = facet_service.search(identity_simple, q=f"id:{id_}", size=25, page=1, facets={"metadata.b": ["xy"]})
     assert hit.total == 1
     assert no_hit.total == 0
+
+
+def test_draft_facets_preset_adds_is_published_facet(
+    app,
+    facet_service,
+    identity_simple,
+    input_facets_data,
+    facet_model,
+    search,
+    search_clear,
+    location,
+):
+    """Test that DraftFacetsPreset adds is_published facet to search options."""
+    assert hasattr(facet_model.facets, "is_published")


### PR DESCRIPTION
is_published is on the level of drafts resources, so I think it belongs in oarepo-model. As for is_draft, this key, does not seem to be indexed in Opensearch i.e. even when you add it to mapping, it is still not dumped into the index. It seems in RDM it is the same situation. I am not sure if we even need it? It is dumped into the API response.