### PR TITLE
fix: fixed schema key not present when restoring a draft

### DIFF
--- a/src/oarepo_model/presets/drafts/records/draft_record.py
+++ b/src/oarepo_model/presets/drafts/records/draft_record.py
@@ -40,6 +40,8 @@ from oarepo_model.presets.records_resources.records.synthetic_metadata import (
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+    from invenio_records_resources.records.api import Record
+
     from oarepo_model.builder import InvenioModelBuilder
 
 
@@ -116,6 +118,18 @@ class DraftPreset(Preset):
                 metadata = MetadataField(key="metadata", synthetic=dependencies["synthetic_metadata"])
             else:
                 metadata = InvenioDraft.metadata
+
+            @classmethod
+            def edit(cls, record: Record) -> InvenioDraft:
+                # invenio-drafts-resources' Draft.edit undelete branch wipes
+                # the draft JSON via undelete() without re-running ConstantField
+                # pre_init hooks, so $schema is missing on the first edit after
+                # publish. Re-inject it from the class-level ConstantField.
+                draft = super().edit(record)  # type: ignore[misc]
+                schema_value = getattr(cls.schema, "value", None)  # type: ignore[attr-defined]
+                if schema_value and "$schema" not in draft:
+                    draft["$schema"] = schema_value
+                return draft
 
         yield AddClass(
             "Draft",


### PR DESCRIPTION
Issue: I make a record, I publish, then in the record manage menu, I click on EDIT, invenio tries to restore the draft, but schema key is missing, https://github.com/oarepo/oarepo-rdm/blob/c1c3775a157aa7d9628af2f03e207d2ed92ce28c/oarepo_rdm/resources/records/response_handlers.py#L131 this crashes. 