### PR TITLE
Zerbe/fix polymorphic types

### DIFF
--- a/oarepo-model-polymorphic-discriminator-issue.md
+++ b/oarepo-model-polymorphic-discriminator-issue.md
@@ -1,0 +1,61 @@
+# Bug: PolymorphicField raises ValidationError on load, silently drops discriminator on dump, raises AssertionError for unknown types
+
+## Affected version
+
+`oarepo-model` v0.1.0dev50 (tag `v0.1.0dev50`).
+**PR target:** upstream `main` (currently at v2.x after major bump #105).
+
+## Summary
+
+`PolymorphicField` has three related bugs in `_serialize` and `_deserialize`:
+
+1. **Load raises `ValidationError: Unknown field`** — the full value dict (including
+   the discriminator key) is passed to the sub-schema, which uses `unknown=RAISE`
+   and does not declare the discriminator field.
+
+2. **Dump silently drops the discriminator** — the sub-schema only serializes its
+   declared fields, so the discriminator key is lost on every dump.  A subsequent
+   load of the dumped value then fails because the discriminator is missing.
+
+3. **Unknown discriminator raises `AssertionError`** — `self.fail('unknown_type', ...)`
+   is called with a key not present in `error_messages`, which causes marshmallow
+   to raise `AssertionError` internally instead of `ValidationError`.
+
+## Steps to reproduce
+
+```python
+# 1. Load fails with ValidationError: Unknown field
+schema.load({"field": {"kind": "type_a", "name": "Muenster"}})
+# ValidationError: {'field': {'kind': ['Unknown field.']}}
+
+# 2. Dump drops the discriminator
+loaded = ... # dict with 'kind' key
+dumped = schema.dump(loaded)
+assert 'kind' in dumped['field']  # AssertionError — 'kind' missing
+
+# 3. Unknown discriminator raises AssertionError
+schema.load({"field": {"kind": "unknown_type", "name": "x"}})
+# AssertionError (not ValidationError)
+```
+
+## Root cause
+
+`_deserialize` passed the full `value` dict (discriminator included) to
+`schema_field._deserialize()`.  `_serialize` did not put the discriminator back
+after calling `schema_field._serialize()`.  `self.fail('unknown_type', ...)` used
+a key not registered in `error_messages`.
+
+## Proposed fix (this branch)
+
+**Commit 1** — Strip the discriminator key from `value` before handing it to the
+sub-schema on `_deserialize`; restore it in the returned dict.  Re-add the
+discriminator to the serialized dict after the sub-schema dumps on `_serialize`.
+Replace `self.fail()` with `raise ma.ValidationError(...)` directly, including
+the list of valid types.
+
+**Commit 2** — Add `preserve_discriminator` parameter (default `True`).  UI schemas
+should not re-inject the discriminator; passing `preserve_discriminator=False` from
+`PolymorphicDataType.create_marshmallow_field` preserves the previous UI behaviour.
+
+**Commit 3** — Tests covering load, dump, round-trip, error paths, and
+polymorphic-in-array.

--- a/src/oarepo_model/datatypes/polymorphic.py
+++ b/src/oarepo_model/datatypes/polymorphic.py
@@ -154,6 +154,7 @@ class PolymorphicDataType(DataType):
             field_name: field_class(
                 discriminator=discriminator,
                 alternatives=alternative_fields,
+                preserve_discriminator=False,
             ),
         }
 
@@ -239,6 +240,7 @@ class PolymorphicField(ma.fields.Field):
         discriminator: str,
         alternatives: dict[str, ma.fields.Field],
         *args: Any,
+        preserve_discriminator: bool = True,
         **kwargs: Any,
     ):
         """Initialize a PolymorphicField for handling discriminated union types.
@@ -250,10 +252,16 @@ class PolymorphicField(ma.fields.Field):
             A mapping from discriminator values (e.g. person/organization)
             to marshmallow field instances. Each field handles validation and
             serialization for its corresponding object variant. Defaults to empty dict.
+        :param preserve_discriminator:
+            When True (default), the discriminator key is re-added to the
+            serialized output after the sub-schema dumps, ensuring round-trip
+            fidelity for data schemas.  Set to False for UI schemas where only
+            UI-transformed fields should appear in the output.
         """
         super().__init__(*args, **kwargs)
         self.discriminator = discriminator
         self.alternatives = alternatives
+        self.preserve_discriminator = preserve_discriminator
 
     def get_discriminator_value(self, obj: Any) -> str:
         """Get the discriminator value from the object."""
@@ -294,7 +302,9 @@ class PolymorphicField(ma.fields.Field):
 
         # Re-add the discriminator: the sub-schema only dumps its declared fields
         # and would otherwise silently drop it, breaking round-trips.
-        if isinstance(serialized, dict):
+        # For UI schemas (preserve_discriminator=False) this step is intentionally
+        # skipped — only UI-transformed fields should appear in the output.
+        if isinstance(serialized, dict) and self.preserve_discriminator:
             serialized[self.discriminator] = discriminator_value
 
         return serialized

--- a/src/oarepo_model/datatypes/polymorphic.py
+++ b/src/oarepo_model/datatypes/polymorphic.py
@@ -281,16 +281,23 @@ class PolymorphicField(ma.fields.Field):
             return value
 
         discriminator_value = self.get_discriminator_value(value)
-        if discriminator_value in self.alternatives:
-            schema_field = self.alternatives[discriminator_value]
-            return schema_field._serialize(  # noqa: SLF001 private access
-                value,
-                attr,
-                obj,
-                **kwargs,
-            )
+        if discriminator_value not in self.alternatives:
+            return value
 
-        return value
+        schema_field = self.alternatives[discriminator_value]
+        serialized = schema_field._serialize(  # noqa: SLF001 private access
+            value,
+            attr,
+            obj,
+            **kwargs,
+        )
+
+        # Re-add the discriminator: the sub-schema only dumps its declared fields
+        # and would otherwise silently drop it, breaking round-trips.
+        if isinstance(serialized, dict):
+            serialized[self.discriminator] = discriminator_value
+
+        return serialized
 
     @override
     def _deserialize(
@@ -304,12 +311,29 @@ class PolymorphicField(ma.fields.Field):
         discriminator_value = self.get_discriminator_value(value)
 
         if discriminator_value not in self.alternatives:
-            self.fail("unknown_type", type=discriminator_value)
+            raise ma.ValidationError(
+                f"Unknown type {discriminator_value!r}. "
+                f"Valid types are: {list(self.alternatives)}",
+            )
+
+        # Strip the discriminator before handing off to the sub-schema.
+        # The sub-schema has unknown=RAISE and does not declare the discriminator
+        # field, so passing the full dict causes ValidationError: Unknown field.
+        value_without_discriminator = {
+            k: v for k, v in value.items() if k != self.discriminator
+        }
 
         schema_field = self.alternatives[discriminator_value]
-        return schema_field._deserialize(  # noqa: SLF001 private access
-            value,
+        result = schema_field._deserialize(  # noqa: SLF001 private access
+            value_without_discriminator,
             attr,
             data,
             **kwargs,
         )
+
+        # Put the discriminator back into the deserialized result so that
+        # _serialize can find it and round-trips are lossless.
+        if isinstance(result, dict):
+            result[self.discriminator] = discriminator_value
+
+        return result

--- a/tests/datatypes/test_polymorphic.py
+++ b/tests/datatypes/test_polymorphic.py
@@ -1,0 +1,195 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see https://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""Tests for the polymorphic bug fix.
+
+Bug 3 — polymorphic: ValidationError "Unknown field" on store because the discriminator
+    key was passed to the sub-schema which had unknown=RAISE; discriminator was also
+    silently dropped on dump; unrecognised discriminator raised AssertionError instead
+    of ValidationError (polymorphic.py).
+"""
+from __future__ import annotations
+
+import pytest
+import marshmallow as ma
+
+
+def make_schema(datatype_registry, element, extra_types=None):
+    """Build a one-field marshmallow Schema for the given element dict."""
+    if extra_types:
+        datatype_registry.add_types(extra_types)
+    field = datatype_registry.get_type(element).create_marshmallow_field(
+        field_name="a",
+        element=element,
+    )
+    return ma.Schema.from_dict({"a": field})()
+
+
+# Sub-schemas used across polymorphic tests.
+# NOTE: the discriminator key ("kind") is intentionally NOT declared as a
+# property of either sub-schema — that is precisely what triggered the bug.
+_TYPE_A_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "fulltext+keyword", "required": True},
+        "is_cheese": {"type": "boolean"},
+    },
+}
+_TYPE_B_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "count": {"type": "int"},
+    },
+}
+_POLYMORPHIC_ELEMENT = {
+    "type": "polymorphic",
+    "discriminator": "kind",
+    "oneof": [
+        {"discriminator": "type_a", "type": "TypeA"},
+        {"discriminator": "type_b", "type": "TypeB"},
+    ],
+}
+_EXTRA_TYPES = {"TypeA": _TYPE_A_SCHEMA, "TypeB": _TYPE_B_SCHEMA}
+
+
+class TestPolymorphicDiscriminatorHandling:
+    """PolymorphicField must strip the discriminator before passing the value
+    to the sub-schema on load, re-add it on dump, and raise a proper
+    ValidationError for unknown discriminator values.
+    """
+
+    @pytest.fixture
+    def schema(self, datatype_registry):
+        return make_schema(datatype_registry, _POLYMORPHIC_ELEMENT, _EXTRA_TYPES)
+
+    # --- deserialization (load) ---
+
+    def test_load_does_not_raise_unknown_field_for_discriminator(self, schema):
+        """Loading a value that includes the discriminator key must not raise
+        ValidationError 'Unknown field' — the discriminator must be stripped
+        before the sub-schema validates the payload.
+        """
+        # Before the fix this raised: ValidationError: {'kind': ['Unknown field.']}
+        result = schema.load({"a": {"kind": "type_a", "name": "Muenster", "is_cheese": True}})
+        assert result is not None
+
+    def test_load_preserves_discriminator_in_result(self, schema):
+        """The deserialized dict must contain the discriminator key so that
+        subsequent serialization can reconstruct the full document.
+        """
+        result = schema.load({"a": {"kind": "type_a", "name": "Muenster", "is_cheese": True}})
+        assert result["a"]["kind"] == "type_a", (
+            "Discriminator must be put back into the deserialized result"
+        )
+
+    def test_load_validates_sub_schema_fields(self, schema):
+        """The sub-schema validation must still run: fields with wrong types
+        must be rejected even after the discriminator stripping fix.
+        """
+        with pytest.raises(ma.ValidationError):
+            # 'name' is required for type_a
+            schema.load({"a": {"kind": "type_a", "is_cheese": True}})
+
+    def test_load_rejects_unknown_fields_in_sub_schema(self, schema):
+        """Extra fields that are not declared in the sub-schema must still
+        be rejected (unknown=RAISE is preserved for payload fields).
+        """
+        with pytest.raises(ma.ValidationError):
+            schema.load({"a": {"kind": "type_a", "name": "ok", "surprise": "boom"}})
+
+    def test_load_second_variant(self, schema):
+        """The fix must work for every discriminator variant, not just the first."""
+        result = schema.load({"a": {"kind": "type_b", "count": 5}})
+        assert result["a"]["kind"] == "type_b"
+        assert result["a"]["count"] == 5
+
+    # --- serialization (dump) ---
+
+    def test_dump_preserves_discriminator(self, schema):
+        """dump() must include the discriminator key in its output.
+        Before the fix it was silently dropped because the sub-schema only
+        serializes declared fields.
+        """
+        loaded = schema.load({"a": {"kind": "type_a", "name": "Gouda", "is_cheese": True}})
+        dumped = schema.dump(loaded)
+        assert "kind" in dumped["a"], (
+            "Discriminator key must be present in the serialized output"
+        )
+        assert dumped["a"]["kind"] == "type_a"
+
+    def test_dump_preserves_payload_fields(self, schema):
+        """dump() must include the sub-schema fields as well as the discriminator."""
+        loaded = schema.load({"a": {"kind": "type_a", "name": "Gouda", "is_cheese": True}})
+        dumped = schema.dump(loaded)
+        assert dumped["a"]["name"] == "Gouda"
+        assert dumped["a"]["is_cheese"] is True
+
+    # --- full round-trip ---
+
+    def test_full_round_trip_type_a(self, schema):
+        """A complete load → dump round-trip must be lossless for type_a."""
+        original = {"a": {"kind": "type_a", "name": "Brie", "is_cheese": True}}
+        assert schema.dump(schema.load(original)) == original
+
+    def test_full_round_trip_type_b(self, schema):
+        """A complete load → dump round-trip must be lossless for type_b."""
+        original = {"a": {"kind": "type_b", "count": 99}}
+        assert schema.dump(schema.load(original)) == original
+
+    # --- error handling ---
+
+    def test_unknown_discriminator_raises_validation_error(self, schema):
+        """An unrecognised discriminator value must raise marshmallow.ValidationError,
+        not AssertionError.  Before the fix, self.fail('unknown_type', ...) raised
+        AssertionError because 'unknown_type' was not in error_messages.
+        """
+        with pytest.raises(ma.ValidationError) as exc_info:
+            schema.load({"a": {"kind": "not_a_real_type", "name": "x"}})
+        # The error message must be a string, not an AssertionError traceback
+        messages = exc_info.value.messages
+        assert isinstance(messages, dict)
+
+    def test_unknown_discriminator_error_message_names_valid_types(self, schema):
+        """The ValidationError for an unknown discriminator must mention the
+        valid types so the caller knows what values are accepted.
+        """
+        with pytest.raises(ma.ValidationError) as exc_info:
+            schema.load({"a": {"kind": "nope", "x": 1}})
+        error_text = str(exc_info.value.messages)
+        assert "type_a" in error_text or "type_b" in error_text, (
+            f"Error message should list valid types, got: {error_text}"
+        )
+
+    def test_missing_discriminator_raises_validation_error(self, schema):
+        """A payload that lacks the discriminator key entirely must raise
+        ValidationError, not KeyError or AttributeError.
+        """
+        with pytest.raises(ma.ValidationError):
+            schema.load({"a": {"name": "no discriminator here"}})
+
+    # --- polymorphic in array ---
+
+    def test_polymorphic_in_array_round_trip(self, datatype_registry):
+        """The same discriminator-stripping fix must apply when polymorphic
+        appears as items in an array field.
+        """
+        schema = make_schema(
+            datatype_registry,
+            {
+                "type": "array",
+                "items": _POLYMORPHIC_ELEMENT,
+            },
+            _EXTRA_TYPES,
+        )
+        original = {
+            "a": [
+                {"kind": "type_a", "name": "Cheddar", "is_cheese": True},
+                {"kind": "type_b", "count": 3},
+            ]
+        }
+        assert schema.dump(schema.load(original)) == original


### PR DESCRIPTION
## Summary

`PolymorphicField` has three related bugs in `_serialize` and `_deserialize`:

1. **Load raises `ValidationError: Unknown field`** — the full value dict (including
   the discriminator key) is passed to the sub-schema, which uses `unknown=RAISE`
   and does not declare the discriminator field.

2. **Dump silently drops the discriminator** — the sub-schema only serializes its
   declared fields, so the discriminator key is lost on every dump.  A subsequent
   load of the dumped value then fails because the discriminator is missing.

3. **Unknown discriminator raises `AssertionError`** — `self.fail('unknown_type', ...)`
   is called with a key not present in `error_messages`, which causes marshmallow
   to raise `AssertionError` internally instead of `ValidationError`.

## Proposed fix (this branch)

**Commit 1** — Strip the discriminator key from `value` before handing it to the
sub-schema on `_deserialize`; restore it in the returned dict.  Re-add the
discriminator to the serialized dict after the sub-schema dumps on `_serialize`.
Replace `self.fail()` with `raise ma.ValidationError(...)` directly, including
the list of valid types.

**Commit 2** — Add `preserve_discriminator` parameter (default `True`).  UI schemas
should not re-inject the discriminator; passing `preserve_discriminator=False` from
`PolymorphicDataType.create_marshmallow_field` preserves the previous UI behaviour.

**Commit 3** — Tests covering load, dump, round-trip, error paths, and
polymorphic-in-array.