### PR TITLE
Zerbe/fix pid relation vocab key mapping

### DIFF
--- a/oarepo-model-pid-relation-vocabulary-key-issue.md
+++ b/oarepo-model-pid-relation-vocabulary-key-issue.md
@@ -1,0 +1,107 @@
+# Bug: `pid-relation` key field referencing a vocabulary term is mapped as scalar `keyword` instead of an object
+
+## Summary
+
+When a `pid-relation` field in a `metadata.yaml` schema lists a key whose value in the target model is itself a vocabulary term (stored as `{"id": "...", "title": {...}}`), oarepo-model generates a mapping entry of `{"type": "keyword"}` for that key. At index time, the denormalized document contains the field as an object `{"id": "analysis"}`, which OpenSearch rejects with a `mapper_parsing_exception` because the mapping declares it a scalar keyword.
+
+## Affected version
+
+`oarepo-model` (tested against the version installed in `frozen_testing`, commit/tag unknown at time of writing)
+
+## Steps to reproduce
+
+1. Define a `pid-relation` field that includes a key pointing to a vocabulary-typed field in the target model. For example, in `dataset/metadata.yaml`:
+
+```yaml
+provenance_activities:
+  type: array
+  items:
+    type: object
+    properties:
+      activity:
+        type: pid-relation
+        keys:
+          - id
+          - metadata.title
+          - metadata.activity_type    # <-- vocabulary field in target model
+        record_cls: "research_activity:ResearchActivityRecord"
+```
+
+2. In the target model (`ResearchActivity`), `activity_type` is a vocabulary reference. When denormalized, it is stored as:
+
+```json
+{
+  "activity": {
+    "id": "kf8y6-0px74",
+    "metadata": {
+      "activity_type": { "id": "analysis" },
+      "title": "Analysis — Rietveld refinement of GIXRD data"
+    },
+    "@v": "1177ccd2-97fc-4115-8b5d-422260b40cda::4"
+  }
+}
+```
+
+3. Inspect the oarepo-generated mapping template:
+
+```python
+from dataset.model import dataset_model
+import json
+mapping = json.loads(dataset_model.__dict__['record-mapping']['content'])
+activity_type = (mapping['mappings']['properties']['metadata']['properties']
+                 ['provenance_activities']['properties']['activity']
+                 ['properties']['metadata']['properties']['activity_type'])
+print(activity_type)
+# {'type': 'keyword', 'ignore_above': 256}
+```
+
+4. Create the OpenSearch index using this template and attempt to index a record.
+
+**Result:**
+```
+opensearchpy.exceptions.RequestError: RequestError(400,
+  'mapper_parsing_exception',
+  "failed to parse field [metadata.provenance_activities.activity.metadata.activity_type]
+   of type [keyword] in document with id '...'.
+   Preview of field's value: '{id=analysis}'")
+```
+
+## Root cause
+
+When oarepo-model generates the mapping for a `pid-relation`'s `keys` list, it looks up the type of each key in the owning model's schema and emits the corresponding OpenSearch type. For `metadata.activity_type` in the target model (`ResearchActivity`), the field is a vocabulary term. Vocabulary terms are stored at index time as objects: `{"id": "...", "title": {...}}` (or, for the denormalized pid-relation snapshot, the subset of keys present in the `@v` cache).
+
+The mapping generator does not traverse the target model to resolve the actual stored shape of the denormalized key. Instead, it appears to emit `{"type": "keyword"}` as a fallback, treating the field as a scalar. The result is a type mismatch between the mapping and the document.
+
+## Impact
+
+Any `pid-relation` whose `keys` include a field that resolves to a vocabulary term in the target model will produce an incorrect mapping entry. When the oarepo template is applied to create the index, any attempt to index a record containing that pid-relation fails, making the record unreachable via the search API.
+
+Reproducible whenever a denormalized pid-relation includes a vocabulary-typed key.
+
+## Proposed fix
+
+The oarepo-model mapping generator should resolve the target model's schema for each listed key and emit the correct OpenSearch mapping for the stored shape. Specifically, a vocabulary-typed key field (whose stored form is `{"id": "..."}` after denormalization) should be emitted as:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "id": {"type": "keyword", "ignore_above": 256}
+  }
+}
+```
+
+If the vocabulary field also stores `title` in the snapshot, the mapping should include `"title": {"type": "object", "dynamic": "true"}` alongside `id`.
+
+### Workaround (applied in this repository)
+
+Explicitly override the affected field's mapping when creating the OpenSearch index, bypassing the oarepo template for this field:
+
+```python
+"activity_type": {
+    "type": "object",
+    "properties": {
+        "id": {"type": "keyword", "ignore_above": 256}
+    }
+}
+```

--- a/src/oarepo_model/datatypes/relations.py
+++ b/src/oarepo_model/datatypes/relations.py
@@ -39,6 +39,14 @@ if TYPE_CHECKING:
     from oarepo_model.customizations.base import Customization
 
 
+VOCABULARY_TERM_MAPPING: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "id": {"type": "keyword", "ignore_above": 256},
+    },
+}
+
+
 class PIDRelation(ObjectDataType):
     """Relation to another record using a PID.
 
@@ -48,12 +56,28 @@ class PIDRelation(ObjectDataType):
         type: pid-relation
         keys:
         - id
-        - metadata.title:
-            type: i18nstr
+        - metadata.title
         record_cls: "my_other_model.records:record" or class   (not required if pid_field is provided)
         pid_field: "my_module:pid_field_getter" or PIDField instance (not required if record_cls is provided)
         cache_key: "my_cache_key" (optional, used for caching the resolved record)
+        vocab_keys:           # keys whose denormalised value is a vocabulary term object
+          - metadata.activity_type
     ```
+
+    String entries in *keys* default to ``{"type": "keyword"}`` in the
+    generated OpenSearch mapping.  If a key resolves to a vocabulary term in
+    the target model the denormalised document stores an *object*
+    ``{"id": "..."}`` rather than a plain string, which causes a
+    ``mapper_parsing_exception`` when the mapping declares it a scalar keyword.
+
+    Declare such keys in ``vocab_keys`` to emit the correct object mapping::
+
+        {"type": "object", "properties": {"id": {"type": "keyword"}}}
+
+    Alternatively, use the explicit dict form in the *keys* list::
+
+        keys:
+          - {metadata.activity_type: {type: object, properties: {id: {type: keyword}}}}
     """
 
     TYPE = "pid-relation"
@@ -80,10 +104,12 @@ class PIDRelation(ObjectDataType):
                     f"Expected 'properties' to be a dict, got {type(element['properties'])}.",
                 )
             return cast("dict[str, Any]", element["properties"])
+        vocab_keys: set[str] = set(element.get("vocab_keys", []))
         ret: dict[str, Any] = {}
         for key in element["keys"]:
             if isinstance(key, str):
-                set_key_model(ret, key, {"type": "keyword"})
+                mapping = VOCABULARY_TERM_MAPPING if key in vocab_keys else {"type": "keyword"}
+                set_key_model(ret, key, mapping)
             elif isinstance(key, dict):
                 for k, v in key.items():
                     set_key_model(ret, k, v)

--- a/tests/datatypes/test_pid_relation_vocab_key.py
+++ b/tests/datatypes/test_pid_relation_vocab_key.py
@@ -1,0 +1,112 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see https://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""Tests for pid-relation vocab_keys mapping fix.
+
+Bug: string keys in a pid-relation default to {type: keyword} in the generated
+OpenSearch mapping. If a key resolves to a vocabulary term in the target model
+the denormalised document stores {id: "..."} — an object — which causes
+mapper_parsing_exception at index time.
+
+Fix: add vocab_keys list to the pid-relation element. Keys listed there are
+mapped as {type: object, properties: {id: {type: keyword}}} instead of the
+scalar keyword default.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestPidRelationVocabKeyMapping:
+    """vocab_keys must produce object mappings for vocabulary-typed fields."""
+
+    def _get_properties(self, datatype_registry, element: dict) -> dict:
+        dt = datatype_registry.get_type(element)
+        return dt._get_properties(element)
+
+    def test_string_key_defaults_to_keyword(self, datatype_registry):
+        """Without vocab_keys, a plain string key produces {type: keyword}."""
+        element = {
+            "type": "pid-relation",
+            "keys": ["id", "metadata.title"],
+            "pid_field": "invenio_pidstore.models:PersistentIdentifier.pid",
+        }
+        props = self._get_properties(datatype_registry, element)
+        assert props["id"]["type"] == "keyword"
+
+    def test_vocab_key_produces_object_mapping(self, datatype_registry):
+        """A key listed in vocab_keys must emit the vocabulary term object mapping.
+
+        Vocabulary terms are stored as {"id": "..."} in the OpenSearch document.
+        The correct mapping is {type: object, properties: {id: {type: keyword}}}.
+        A scalar keyword mapping causes mapper_parsing_exception at index time.
+        """
+        element = {
+            "type": "pid-relation",
+            "keys": ["id", "metadata.activity_type"],
+            "vocab_keys": ["metadata.activity_type"],
+            "pid_field": "invenio_pidstore.models:PersistentIdentifier.pid",
+        }
+        props = self._get_properties(datatype_registry, element)
+        activity_type_mapping = props.get("metadata", {}).get("properties", {}).get("activity_type")
+        assert activity_type_mapping is not None, "activity_type missing from properties"
+        assert activity_type_mapping.get("type") == "object", (
+            f"vocab_key should be mapped as object, got {activity_type_mapping!r}. "
+            "Vocabulary terms are stored as {{id: ...}} at index time; scalar keyword "
+            "causes mapper_parsing_exception."
+        )
+        assert "id" in activity_type_mapping.get("properties", {}), (
+            "Vocabulary term object mapping must include 'id' sub-field"
+        )
+
+    def test_non_vocab_key_unchanged_when_vocab_keys_present(self, datatype_registry):
+        """Keys not in vocab_keys remain as keyword even when vocab_keys is set."""
+        element = {
+            "type": "pid-relation",
+            "keys": ["id", "metadata.title", "metadata.activity_type"],
+            "vocab_keys": ["metadata.activity_type"],
+            "pid_field": "invenio_pidstore.models:PersistentIdentifier.pid",
+        }
+        props = self._get_properties(datatype_registry, element)
+        title_mapping = props.get("metadata", {}).get("properties", {}).get("title")
+        assert title_mapping is not None
+        assert title_mapping.get("type") == "keyword", (
+            f"Non-vocab key should remain keyword, got {title_mapping!r}"
+        )
+
+    def test_dict_form_still_works_for_custom_overrides(self, datatype_registry):
+        """Explicit dict form in keys overrides the default regardless of vocab_keys."""
+        custom_mapping = {
+            "type": "object",
+            "properties": {"id": {"type": "keyword"}, "title": {"type": "object"}},
+        }
+        element = {
+            "type": "pid-relation",
+            "keys": [
+                "id",
+                {"metadata.activity_type": custom_mapping},
+            ],
+            "pid_field": "invenio_pidstore.models:PersistentIdentifier.pid",
+        }
+        props = self._get_properties(datatype_registry, element)
+        activity_type_mapping = props.get("metadata", {}).get("properties", {}).get("activity_type")
+        assert activity_type_mapping == custom_mapping
+
+    def test_empty_vocab_keys_behaves_as_no_vocab_keys(self, datatype_registry):
+        """An empty vocab_keys list must not change any key mappings."""
+        element = {
+            "type": "pid-relation",
+            "keys": ["id", "metadata.title"],
+            "vocab_keys": [],
+            "pid_field": "invenio_pidstore.models:PersistentIdentifier.pid",
+        }
+        props = self._get_properties(datatype_registry, element)
+        title_mapping = props.get("metadata", {}).get("properties", {}).get("title")
+        assert title_mapping is not None
+        assert title_mapping.get("type") == "keyword"


### PR DESCRIPTION
When a `pid-relation` field in a `metadata.yaml` schema lists a key whose value in the target model is itself a vocabulary term (stored as `{"id": "...", "title": {...}}`), oarepo-model generates a mapping entry of `{"type": "keyword"}` for that key. At index time, the denormalized document contains the field as an object `{"id": "analysis"}`, which OpenSearch rejects with a `mapper_parsing_exception` because the mapping declares it a scalar keyword.

The patch adds code implementing vocabulary term mapping so that vocabular term is mapped correctly as an object.