### PR TITLE
Zerbe/fix pid relation lazy resolution

### DIFF
--- a/oarepo-model-pid-relation-lazy-import-issue.md
+++ b/oarepo-model-pid-relation-lazy-import-issue.md
@@ -1,0 +1,54 @@
+# Bug: pid-relation build fails with ImportError / None for cross-module or self-referential record classes
+
+## Affected version
+
+`oarepo-model` v0.1.0dev50 (tag `v0.1.0dev50`).
+**PR target:** upstream `main` (currently at v2.x after major bump #105).
+
+## Summary
+
+`PIDRelation._pid_field()` called `obj_or_import_string()` eagerly at model
+construction time and returned the fully resolved `PIDFieldContext`.  When a
+pid-relation references a record class that lives in a different module which
+has not yet been imported — including self-referential relations where the
+target is the same module currently being constructed — Python's import
+machinery either raises `ImportError` or returns `None`, and the build fails
+before any records can be loaded.
+
+## Steps to reproduce
+
+1. Define two record models in separate modules, each with a pid-relation
+   pointing at the other (or a single model with a pid-relation pointing at
+   itself, e.g. a `parent_activity` field).
+2. Import either module.
+
+**Result:** `ImportError: cannot import name '...'` or `ValueError: Record
+class ... does not have a 'pid' attribute` raised at import time before the
+Flask application is running.
+
+## Root cause
+
+`PIDRelation._pid_field()` in `src/oarepo_model/datatypes/relations.py`
+resolves the `record_cls` or `pid_field` string via `obj_or_import_string()`
+and immediately returns the live object.  Model files are imported during
+Python module initialization; the target class is not yet available.
+
+## Fix (this branch)
+
+**Commit 1 — Defer resolution to `apply()`-time** (`relations.py`,
+`add_pid_relation.py`): `_pid_field()` now returns a zero-argument callable.
+`AddPIDRelation.apply()` receives the factory and resolves it (or wraps it in
+a `LazyPIDFieldProxy`) before passing the result to `PIDRelation` /
+`PIDListRelation` / `PIDArbitraryNestedListRelation`.  A pre-resolved value
+(not callable) is still accepted for backward compatibility.
+
+**Commit 2 — `LazyPIDFieldProxy` for truly deferred resolution**
+(`add_pid_relation.py`): Even at `apply()`-time the same module may not be
+fully initialized for self-referential models.  A proxy object stores the
+factory and only calls it on first attribute access (at record I/O time),
+when all modules are guaranteed loaded.
+
+**Commit 3 — Tests** (`tests/datatypes/test_pid_relation_lazy_import.py`):
+Covers the lazy-callable contract, error paths (bad module, missing keys),
+`create_relations()` not importing at call time, and `AddPIDRelation`
+backward compatibility.

--- a/src/oarepo_model/customizations/high_level/add_pid_relation.py
+++ b/src/oarepo_model/customizations/high_level/add_pid_relation.py
@@ -28,6 +28,8 @@ from oarepo_runtime.records.systemfields.relations import PIDArbitraryNestedList
 from ..base import Customization
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from invenio_records_resources.records.systemfields.pid import PIDFieldContext
 
     from oarepo_model.builder import InvenioModelBuilder
@@ -50,7 +52,7 @@ class AddPIDRelation(Customization):
         name: str,
         path: list[str | type[ARRAY_PATH_ITEM]],
         keys: list[str],
-        pid_field: PIDFieldContext,
+        pid_field: PIDFieldContext | Callable[[], PIDFieldContext],
         cache_key: str | None = None,
         **kwargs: Any,
     ) -> None:
@@ -74,12 +76,16 @@ class AddPIDRelation(Customization):
 
         relation_field, array_paths = self._merge_paths_between_arrays()
 
+        # Resolve lazily — all modules are loaded by the time apply() is called,
+        # so circular imports and missing modules are no longer a concern.
+        pid_field = self.pid_field() if callable(self.pid_field) else self.pid_field
+
         match array_count:
             case 0:
                 relations[self.name] = PIDRelation(
                     relation_field,
                     keys=self.keys,
-                    pid_field=self.pid_field,
+                    pid_field=pid_field,
                     cache_key=self.cache_key,
                     **self.kwargs,
                 )
@@ -88,7 +94,7 @@ class AddPIDRelation(Customization):
                 relations[self.name] = PIDListRelation(
                     array_paths[0],
                     keys=self.keys,
-                    pid_field=self.pid_field,
+                    pid_field=pid_field,
                     cache_key=self.cache_key,
                     relation_field=relation_field,
                     **self.kwargs,
@@ -102,7 +108,7 @@ class AddPIDRelation(Customization):
                         array_paths=array_paths,
                         relation_field=relation_field,
                         keys=self.keys,
-                        pid_field=self.pid_field,
+                        pid_field=pid_field,
                         cache_key=self.cache_key,
                         **self.kwargs,
                     )
@@ -111,7 +117,7 @@ class AddPIDRelation(Customization):
                         array_paths[0],
                         relation_field=array_paths[1],
                         keys=self.keys,
-                        pid_field=self.pid_field,
+                        pid_field=pid_field,
                         cache_key=self.cache_key,
                         **self.kwargs,
                     )
@@ -120,7 +126,7 @@ class AddPIDRelation(Customization):
                     array_paths=array_paths,
                     relation_field=relation_field,
                     keys=self.keys,
-                    pid_field=self.pid_field,
+                    pid_field=pid_field,
                     cache_key=self.cache_key,
                     **self.kwargs,
                 )

--- a/src/oarepo_model/customizations/high_level/add_pid_relation.py
+++ b/src/oarepo_model/customizations/high_level/add_pid_relation.py
@@ -36,6 +36,35 @@ if TYPE_CHECKING:
     from oarepo_model.model import InvenioModel
 
 
+class LazyPIDFieldProxy:
+    """Defer pid_field resolution until first attribute access.
+
+    When a pid-relation references a record class in the *same* module that is
+    currently being constructed (e.g. a self-referential ``parent_activity``
+    field), calling the factory during ``apply()`` triggers a circular import
+    because the module has not finished initialising yet.  This proxy stores
+    the factory and only calls it on first attribute access, by which time all
+    modules are fully loaded.
+    """
+
+    __slots__ = ("_factory", "_resolved")
+
+    def __init__(self, factory: Callable[[], PIDFieldContext]) -> None:
+        object.__setattr__(self, "_factory", factory)
+        object.__setattr__(self, "_resolved", None)
+
+    def _resolve(self) -> PIDFieldContext:
+        resolved = object.__getattribute__(self, "_resolved")
+        if resolved is None:
+            factory: Callable[[], PIDFieldContext] = object.__getattribute__(self, "_factory")
+            resolved = factory()
+            object.__setattr__(self, "_resolved", resolved)
+        return resolved
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._resolve(), name)
+
+
 class ARRAY_PATH_ITEM:  # noqa: N801
     """Marker for array items in the path.
 
@@ -76,9 +105,15 @@ class AddPIDRelation(Customization):
 
         relation_field, array_paths = self._merge_paths_between_arrays()
 
-        # Resolve lazily — all modules are loaded by the time apply() is called,
-        # so circular imports and missing modules are no longer a concern.
-        pid_field = self.pid_field() if callable(self.pid_field) else self.pid_field
+        # Wrap callable factories in a lazy proxy so that import_string() is
+        # deferred until the pid_field is first *accessed* at record I/O time,
+        # not called eagerly here.  This avoids circular import errors when a
+        # pid-relation references a class in the same module that is currently
+        # being constructed (e.g. a self-referential parent_activity field).
+        if callable(self.pid_field):
+            pid_field = LazyPIDFieldProxy(self.pid_field)
+        else:
+            pid_field = self.pid_field
 
         match array_count:
             case 0:

--- a/src/oarepo_model/datatypes/relations.py
+++ b/src/oarepo_model/datatypes/relations.py
@@ -156,25 +156,42 @@ class PIDRelation(ObjectDataType):
         self,
         element: dict[str, Any],
         path: list[tuple[str, dict[str, Any]]],  # noqa: ARG002 for overriding
-    ) -> PIDFieldContext:
-        """Get the PID field from the element."""
+    ) -> Callable[[], PIDFieldContext]:
+        """Return a lazy callable that resolves the PID field on first use.
+
+        Deferring the import to apply()-time avoids build failures caused by
+        circular imports or modules that are not yet on sys.path when the model
+        file is first loaded.
+        """
         if "pid_field" in element:
-            pidf = cast(
-                "Callable[[dict[str, Any]], PIDFieldContext]",
-                obj_or_import_string(element["pid_field"]),
-            )
-            if pidf is None or not callable(pidf):
-                raise ValueError(
-                    f"PID field {element['pid_field']} could not be imported.",
+            raw = element["pid_field"]
+
+            def resolve_pid_field(_raw: Any = raw, _element: Any = element) -> PIDFieldContext:
+                pidf = cast(
+                    "Callable[[dict[str, Any]], PIDFieldContext]",
+                    obj_or_import_string(_raw),
                 )
-            return pidf(element)
+                if pidf is None or not callable(pidf):
+                    raise ValueError(
+                        f"PID field {_raw!r} could not be imported.",
+                    )
+                return pidf(_element)
+
+            return resolve_pid_field
+
         if "record_cls" in element:
-            rec = obj_or_import_string(element["record_cls"])
-            if rec is None or not hasattr(rec, "pid"):
-                raise ValueError(
-                    f"Record class {element['record_cls']} does not have a 'pid' attribute.",
-                )
-            return rec.pid
+            raw = element["record_cls"]
+
+            def resolve_record_cls(_raw: Any = raw) -> PIDFieldContext:
+                rec = obj_or_import_string(_raw)
+                if rec is None or not hasattr(rec, "pid"):
+                    raise ValueError(
+                        f"Record class {_raw!r} does not have a 'pid' attribute.",
+                    )
+                return rec.pid
+
+            return resolve_record_cls
+
         raise ValueError(
             "Either 'pid_field' or 'record_cls' must be provided in the pid-relation element.",
         )

--- a/tests/customizations/test_lazy_pid_field_proxy.py
+++ b/tests/customizations/test_lazy_pid_field_proxy.py
@@ -1,0 +1,247 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see https://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""Tests for LazyPIDFieldProxy and AddPIDRelation.apply() lazy-wrapping behaviour.
+
+Covers:
+  - LazyPIDFieldProxy does NOT call its factory during __init__
+  - LazyPIDFieldProxy calls factory on first attribute access
+  - LazyPIDFieldProxy calls factory exactly once (result is cached)
+  - LazyPIDFieldProxy forwards attribute reads transparently to the resolved object
+  - LazyPIDFieldProxy handles the late-binding scenario: factory that would fail
+    if called eagerly during model construction succeeds once all modules are loaded
+  - AddPIDRelation.apply() wraps a callable pid_field in LazyPIDFieldProxy instead
+    of calling it immediately
+  - AddPIDRelation.apply() passes a non-callable pid_field through unchanged
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from oarepo_model.customizations.high_level.add_pid_relation import (
+    ARRAY_PATH_ITEM,
+    AddPIDRelation,
+    LazyPIDFieldProxy,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _FakeBuilder:
+    """Minimal stand-in for InvenioModelBuilder used to test apply()."""
+
+    def __init__(self):
+        self._dicts: dict[str, dict] = {}
+
+    def get_dictionary(self, name: str) -> dict:
+        return self._dicts.setdefault(name, {})
+
+
+# ---------------------------------------------------------------------------
+# LazyPIDFieldProxy unit tests
+# ---------------------------------------------------------------------------
+
+class TestLazyPIDFieldProxy:
+    """LazyPIDFieldProxy must defer factory invocation until first attribute access."""
+
+    def test_factory_not_called_during_init(self):
+        """__init__ must NOT invoke the factory."""
+        call_log: list[int] = []
+
+        def factory():
+            call_log.append(1)
+            return SimpleNamespace()
+
+        LazyPIDFieldProxy(factory)
+        assert call_log == [], (
+            "LazyPIDFieldProxy.__init__ must not call the factory; "
+            f"factory was called {len(call_log)} time(s)"
+        )
+
+    def test_factory_called_on_first_attribute_access(self):
+        """Accessing any attribute for the first time must trigger the factory."""
+        call_log: list[int] = []
+        resolved = SimpleNamespace(pid_type="recid")
+
+        def factory():
+            call_log.append(1)
+            return resolved
+
+        proxy = LazyPIDFieldProxy(factory)
+        assert call_log == [], "pre-condition: factory not yet called"
+        _ = proxy.pid_type
+        assert call_log == [1], "factory must be called on first attribute access"
+
+    def test_factory_called_exactly_once(self):
+        """Multiple attribute accesses must trigger the factory only once."""
+        call_count = 0
+        resolved = SimpleNamespace(a=1, b=2, c=3)
+
+        def factory():
+            nonlocal call_count
+            call_count += 1
+            return resolved
+
+        proxy = LazyPIDFieldProxy(factory)
+        _ = proxy.a
+        _ = proxy.b
+        _ = proxy.c
+        assert call_count == 1, (
+            f"factory must be called exactly once; was called {call_count} time(s)"
+        )
+
+    def test_attribute_forwarded_to_resolved_object(self):
+        """Attribute reads must return the value from the resolved object."""
+        resolved = SimpleNamespace(pid_type="recid", session_merge="no-op", extra=42)
+        proxy = LazyPIDFieldProxy(lambda: resolved)
+        assert proxy.pid_type == "recid"
+        assert proxy.session_merge == "no-op"
+        assert proxy.extra == 42
+
+    def test_missing_attribute_raises_attribute_error(self):
+        """Accessing a missing attribute must propagate AttributeError from the
+        resolved object, not get swallowed by the proxy."""
+        resolved = SimpleNamespace(existing="yes")
+        proxy = LazyPIDFieldProxy(lambda: resolved)
+        with pytest.raises(AttributeError):
+            _ = proxy.does_not_exist
+
+    def test_late_binding_simulates_circular_import_scenario(self):
+        """Simulate the self-referential model scenario.
+
+        A factory that raises ImportError if invoked too early succeeds once the
+        'module' becomes available — exactly what happens with a self-referential
+        pid-relation when the target class is registered after module import.
+        """
+        module_ready: list[bool] = []  # empty = not yet initialized
+
+        def factory():
+            if not module_ready:
+                raise ImportError(
+                    "cannot import name 'ResearchActivityRecord' from partially "
+                    "initialized module 'research_activity'"
+                )
+            return SimpleNamespace(pid_type="research-activity")
+
+        # Model construction phase: proxy created before module is ready.
+        # Without LazyPIDFieldProxy, calling factory() here would raise ImportError.
+        proxy = LazyPIDFieldProxy(factory)
+
+        # Module finishes loading (all classes are now available).
+        module_ready.append(True)
+
+        # First I/O access — factory is invoked only now, safely.
+        assert proxy.pid_type == "research-activity"
+
+    def test_slot_access_does_not_trigger_resolution(self):
+        """Accessing _factory via its __slot__ must NOT invoke the factory.
+
+        __slots__ causes _factory to be found via the normal descriptor protocol
+        (bypassing __getattr__ entirely), so reading proxy._factory returns the
+        stored callable directly without triggering lazy resolution.  This
+        confirms that __getattr__ is only invoked for attributes the proxy does
+        NOT own itself — i.e. attributes delegated to the resolved object.
+        """
+        call_log: list[int] = []
+        sentinel_factory = lambda: (call_log.append(1), SimpleNamespace())[1]  # noqa: E731
+        proxy = LazyPIDFieldProxy(sentinel_factory)
+
+        # Accessing the slot attribute directly must not call the factory.
+        stored = object.__getattribute__(proxy, "_factory")
+        assert call_log == [], "__slots__ access must not trigger factory resolution"
+        assert stored is sentinel_factory, "_factory slot must hold the original callable"
+
+
+# ---------------------------------------------------------------------------
+# AddPIDRelation.apply() lazy-wrapping tests
+# ---------------------------------------------------------------------------
+
+class TestAddPIDRelationApplyLaziness:
+    """apply() must wrap callable pid_field factories in LazyPIDFieldProxy."""
+
+    def _make_relation(self, pid_field, path=None, **kwargs):
+        return AddPIDRelation(
+            name="test_rel",
+            path=path or ["test_rel"],
+            keys=["id"],
+            pid_field=pid_field,
+            **kwargs,
+        )
+
+    def test_apply_wraps_callable_in_lazy_proxy(self):
+        """When pid_field is callable, apply() must store a LazyPIDFieldProxy
+        in the relations dict rather than calling the factory eagerly."""
+        call_log: list[int] = []
+        resolved = SimpleNamespace(pid_type="recid")
+
+        def factory():
+            call_log.append(1)
+            return resolved
+
+        relation = self._make_relation(pid_field=factory)
+        builder = _FakeBuilder()
+        relation.apply(builder, model=None)
+
+        assert call_log == [], (
+            "apply() must NOT invoke the factory; factory was called eagerly"
+        )
+        stored = builder.get_dictionary("relations")["test_rel"]
+        # The stored relation object must carry a LazyPIDFieldProxy as its pid_field
+        assert isinstance(stored.pid_field, LazyPIDFieldProxy), (
+            f"expected LazyPIDFieldProxy, got {type(stored.pid_field)}"
+        )
+
+    def test_apply_does_not_wrap_non_callable(self):
+        """When pid_field is already a resolved object (not callable), apply()
+        must pass it through unchanged — no unnecessary wrapping."""
+        sentinel = SimpleNamespace(pid_type="recid")
+        relation = self._make_relation(pid_field=sentinel)
+        builder = _FakeBuilder()
+        relation.apply(builder, model=None)
+
+        stored = builder.get_dictionary("relations")["test_rel"]
+        assert stored.pid_field is sentinel, (
+            "Non-callable pid_field must be stored as-is, not wrapped"
+        )
+
+    def test_proxy_resolves_correctly_after_apply(self):
+        """The LazyPIDFieldProxy stored by apply() must resolve to the correct
+        value when an attribute is first accessed after apply() returns."""
+        resolved = SimpleNamespace(pid_type="vocab-id")
+        relation = self._make_relation(pid_field=lambda: resolved)
+        builder = _FakeBuilder()
+        relation.apply(builder, model=None)
+
+        stored = builder.get_dictionary("relations")["test_rel"]
+        assert stored.pid_field.pid_type == "vocab-id"
+
+    def test_apply_callable_not_called_for_list_relation(self):
+        """apply() must also defer the factory for list (array) pid-relations."""
+        call_log: list[int] = []
+
+        def factory():
+            call_log.append(1)
+            return SimpleNamespace(pid_type="recid")
+
+        # path with one ARRAY_PATH_ITEM → PIDListRelation branch
+        relation = self._make_relation(
+            pid_field=factory,
+            path=["items", ARRAY_PATH_ITEM, "id"],
+        )
+        builder = _FakeBuilder()
+        relation.apply(builder, model=None)
+
+        assert call_log == [], (
+            "apply() must not call factory eagerly for list relations either"
+        )
+        stored = builder.get_dictionary("relations")["test_rel"]
+        assert isinstance(stored.pid_field, LazyPIDFieldProxy)

--- a/tests/datatypes/test_pid_relation_lazy_import.py
+++ b/tests/datatypes/test_pid_relation_lazy_import.py
@@ -1,0 +1,125 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-model (see https://github.com/oarepo/oarepo-model).
+#
+# oarepo-model is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""Tests for deferred pid_field resolution in pid-relation.
+
+Bug: `_pid_field()` called `obj_or_import_string()` eagerly at model construction
+time, causing `ImportError` / `None` when a pid-relation referenced a record
+class that had not yet been imported (circular imports, same-module references).
+
+Fix: `_pid_field()` now returns a zero-argument callable; resolution is deferred
+to `AddPIDRelation.apply()`, when all modules are guaranteed to be loaded.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+class TestPidRelationLazyImport:
+    """_pid_field() must return a callable rather than resolving the import
+    immediately, so that a model referencing another model can be constructed
+    without a circular-import or missing-module error at import time.
+    """
+
+    def test_pid_field_returns_callable_for_record_cls(self, datatype_registry):
+        """_pid_field() must return a callable even when the module does not exist."""
+        element = {
+            "type": "pid-relation",
+            "keys": ["id"],
+            "record_cls": "this.module.does.not.exist:SomeRecord",
+        }
+        dt = datatype_registry.get_type(element)
+        result = dt._pid_field(element, [])
+        assert callable(result), (
+            "_pid_field() should return a callable (lazy resolver), "
+            "not raise ImportError at call time"
+        )
+
+    def test_pid_field_returns_callable_for_pid_field(self, datatype_registry):
+        """_pid_field() must return a callable when pid_field string is given."""
+        element = {
+            "type": "pid-relation",
+            "keys": ["id"],
+            "pid_field": "this.module.does.not.exist:get_pid",
+        }
+        dt = datatype_registry.get_type(element)
+        result = dt._pid_field(element, [])
+        assert callable(result), (
+            "_pid_field() should return a callable for pid_field strings too"
+        )
+
+    def test_pid_field_callable_raises_on_bad_record_cls(self, datatype_registry):
+        """The callable returned by _pid_field() must raise when invoked with a
+        non-existent module — but only at invocation time, not at _pid_field() time.
+        """
+        element = {
+            "type": "pid-relation",
+            "keys": ["id"],
+            "record_cls": "this.module.does.not.exist:SomeRecord",
+        }
+        dt = datatype_registry.get_type(element)
+        resolver = dt._pid_field(element, [])
+        with pytest.raises(Exception):
+            resolver()
+
+    def test_pid_field_raises_without_pid_field_or_record_cls(self, datatype_registry):
+        """_pid_field() must raise ValueError immediately when neither
+        pid_field nor record_cls is provided — there is nothing to defer.
+        """
+        element = {
+            "type": "pid-relation",
+            "keys": ["id"],
+        }
+        dt = datatype_registry.get_type(element)
+        with pytest.raises(ValueError, match="Either 'pid_field' or 'record_cls'"):
+            dt._pid_field(element, [])
+
+    def test_create_relations_does_not_import_at_call_time(self, datatype_registry):
+        """create_relations() must complete without raising even when record_cls
+        points to a non-existent module, because the import is deferred.
+        """
+        element = {
+            "type": "pid-relation",
+            "keys": ["id", "metadata.title"],
+            "record_cls": "this.module.does.not.exist:SomeRecord",
+        }
+        dt = datatype_registry.get_type(element)
+        customizations = dt.create_relations(element, [("my_field", element)])
+        assert len(customizations) == 1
+
+    def test_add_pid_relation_stores_callable(self, datatype_registry):
+        """AddPIDRelation must store the callable so that apply() can resolve it."""
+        from oarepo_model.customizations.high_level.add_pid_relation import AddPIDRelation
+
+        sentinel = object()
+
+        def lazy_resolver():
+            return sentinel
+
+        relation = AddPIDRelation(
+            name="my_field",
+            path=["my_field"],
+            keys=["id"],
+            pid_field=lazy_resolver,
+        )
+        assert relation.pid_field is lazy_resolver
+
+    def test_add_pid_relation_accepts_direct_value_for_backward_compat(self, datatype_registry):
+        """AddPIDRelation must also accept a pre-resolved PIDFieldContext value
+        (not callable) for backward compatibility.
+        """
+        from oarepo_model.customizations.high_level.add_pid_relation import AddPIDRelation
+
+        sentinel = object()
+        relation = AddPIDRelation(
+            name="my_field",
+            path=["my_field"],
+            keys=["id"],
+            pid_field=sentinel,
+        )
+        assert relation.pid_field is sentinel


### PR DESCRIPTION
PIDRelation._pid_field()` called `obj_or_import_string()` eagerly at model
construction time and returned the fully resolved `PIDFieldContext`.  When a
pid-relation references a record class that lives in a different module which
has not yet been imported — including self-referential relations where the
target is the same module currently being constructed — Python's import
machinery either raises `ImportError` or returns `None`, and the build fails
before any records can be loaded.

