### PR TITLE
fix: removed localproxy wrapper from jsonuiserlializer

### DIFF
--- a/src/oarepo_model/presets/records_resources/resources/records/register_ui_json_serializer.py
+++ b/src/oarepo_model/presets/records_resources/resources/records/register_ui_json_serializer.py
@@ -19,10 +19,9 @@ resource response handlers. It includes:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast, override
+from typing import TYPE_CHECKING, Any, override
 
 from invenio_i18n import lazy_gettext as _
-from werkzeug.local import LocalProxy
 
 from oarepo_model.customizations import (
     AddMetadataExport,
@@ -33,8 +32,6 @@ from oarepo_model.presets import Preset
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-    from flask_resources.serializers import BaseSerializer
-
     from oarepo_model.builder import InvenioModelBuilder
     from oarepo_model.model import InvenioModel
 
@@ -42,7 +39,7 @@ if TYPE_CHECKING:
 class RegisterJSONUISerializerPreset(Preset):
     """Preset for registering JSON UI Serializer."""
 
-    depends_on = ("JSONUISerializer",)
+    depends_on = ("JSONUISerializer", "RecordUISchema")
     modifies = ("exports",)
 
     @override
@@ -52,14 +49,12 @@ class RegisterJSONUISerializerPreset(Preset):
         model: InvenioModel,
         dependencies: dict[str, Any],
     ) -> Generator[Customization]:
-        runtime_deps = builder.get_runtime_dependencies()
+        json_ui_serializer_cls = dependencies["JSONUISerializer"]
+        record_ui_schema_cls = dependencies["RecordUISchema"]
 
         yield AddMetadataExport(
             code="ui_json",
             name=_("UI JSON"),
             mimetype="application/vnd.inveniordm.v1+json",
-            serializer=cast(
-                "BaseSerializer",
-                LocalProxy(lambda: runtime_deps.get("JSONUISerializer")()),  # noqa: PLW0108
-            ),
+            serializer=json_ui_serializer_cls(object_schema_cls=record_ui_schema_cls),
         )

--- a/src/oarepo_model/presets/records_resources/resources/records/ui_json_serializer.py
+++ b/src/oarepo_model/presets/records_resources/resources/records/ui_json_serializer.py
@@ -45,16 +45,14 @@ class JSONUISerializerPreset(Preset):
         model: InvenioModel,
         dependencies: dict[str, Any],
     ) -> Generator[Customization]:
-        runtime_dependencies = builder.get_runtime_dependencies()
-
         class JSONUISerializer(MarshmallowSerializer):
             """UI JSON serializer."""
 
-            def __init__(self):
+            def __init__(self, object_schema_cls: type):
                 """Initialise Serializer."""
                 super().__init__(
                     format_serializer_cls=JSONSerializer,
-                    object_schema_cls=runtime_dependencies.get("RecordUISchema"),
+                    object_schema_cls=object_schema_cls,
                     list_schema_cls=BaseListSchema,
                     schema_context={"object_key": "ui"},
                 )


### PR DESCRIPTION
I think that correct solution to this problem is to not use Localproxy for jsonserializer and then https://github.com/oarepo/oarepo-rdm/pull/83/changes we could go back to using type check. Alternatively, as we know this serializer is a local proxy, we could unwrap it and do type check after unwrapping. Please take a look.