### PR TITLE
Major version bump due to major bump in packages: invenio-rdm-records, oarepo-runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-model"
-version = "2.4.0"
+version = "3.0.0"
 description = "Dynamic models for InvenioRDM"
 readme = "README.md"
 authors = [
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.14,<3.15"
 dependencies = [
-    "oarepo-runtime>=4.0.0,<5.0.0",
+    "oarepo-runtime>=5.0.0,<6.0.0",
     "graphlib",
     "oarepo[rdm,tests]>=14.0.0,<15.0.0",
     "deepmerge>=2.0",
@@ -16,7 +16,7 @@ dependencies = [
     "marshmallow-i18n-messages>=0.1.0",
     "wrapt",
     # invenio dependencies
-    "invenio-rdm-records>=28.0.0,<29.0.0",
+    "invenio-rdm-records>=29.0.0,<30.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Major version bump due to major bump in packages: invenio-rdm-records, oarepo-runtime.

## Included pull requests

- fix: added value labels ([#120](https://github.com/oarepo/oarepo-model/pull/120))
